### PR TITLE
made a quick fix for missing .tailscale folder

### DIFF
--- a/remote-install.sh
+++ b/remote-install.sh
@@ -4,6 +4,10 @@ set -eu
 echo "Tailscale Termux Remote Installer"
 echo "=============================="
 
+# if anyone can do a check for this instead of hardcoding it to check, that would be amazing. I am too lazy to write this honestly and just decided to make a quick hot patch to make a pull request. Thank you
+pkg install wget
+mkdir -p ~/.tailscale
+
 REPO="bropines/tailscale-termux-cli"
 BIN_DIR="${PREFIX:-/data/data/com.termux/files/usr}/bin"
 STATE_DIR="$HOME/.tailscale"


### PR DESCRIPTION
This pull request makes a small but important improvement to the `remote-install.sh` script by ensuring that the `wget` package is installed and the `~/.tailscale` directory exists before proceeding with the installation.

- Installation prerequisites:
  * Adds a command to install `wget` using `pkg` to ensure the script can download necessary files.
  * Creates the `~/.tailscale` directory if it doesn't already exist, preventing potential errors later in the script.