### PR TITLE
Fix audit blockers: ship patches on all architectures, authenticate SOCKS5, repair CI releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,11 +81,32 @@ jobs:
         run: |
           mkdir -p release_assets
           find artifacts/ -type f \( -name "tailscale-*" -o -name "tailscaled-*" -o -name "*.deb" \) -exec cp {} release_assets/ \;
+          # Publish checksums: remote-install.sh and tailscale-update pull these
+          # assets over plain HTTPS with nothing to verify them against.
+          ( cd release_assets && sha256sum ./* > SHA256SUMS )
           echo "Release assets prepared:"
           ls -la release_assets/
+          cat release_assets/SHA256SUMS
+
+      # A reusable workflow inherits the CALLER's event, so on the nightly
+      # check-updates run github.event_name is "schedule" and github.ref is
+      # "refs/heads/main" -- every disjunct of the old condition was false and
+      # the release step silently skipped while the job still reported success.
+      # inputs.ts_version is populated on both workflow_call and
+      # workflow_dispatch, and empty on a tag push.
+      - name: Decide whether to publish
+        id: gate
+        env:
+          TS_VERSION_INPUT: ${{ inputs.ts_version }}
+        run: |
+          if [ -n "$TS_VERSION_INPUT" ] || [ "${GITHUB_REF#refs/tags/}" != "$GITHUB_REF" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch'
+        if: steps.gate.outputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.ts_version || github.event.inputs.ts_version || github.ref_name }}
@@ -98,7 +119,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Combined Artifacts
-        if: ${{ ! (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') }}
+        if: steps.gate.outputs.publish != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: tailscale-termux-cli-binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  # Build (but never publish) on PRs. The repository had no PR check at all,
+  # which is how three architectures shipped for months without the netmon
+  # patch: build.sh's verify_patched now fails that build instead.
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       ts_version:
@@ -48,7 +53,7 @@ jobs:
 
       - name: Build Binaries and Deb Package
         env:
-          TS_VERSION: ${{ inputs.ts_version || github.event.inputs.ts_version || github.ref_name }}
+          TS_VERSION: ${{ inputs.ts_version || github.event.inputs.ts_version || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || '' }}
         run: |
           chmod +x ./build_deb.sh ./build.sh
           ./build_deb.sh ${{ matrix.arch }}
@@ -110,11 +115,11 @@ jobs:
         if: steps.gate.outputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.ts_version || github.event.inputs.ts_version || github.ref_name }}
+          tag_name: ${{ inputs.ts_version || github.event.inputs.ts_version || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || '' }}
           files: release_assets/*
           body: |
             Patched Tailscale binaries and .deb packages for Termux (Android 11+).
-            Based on Tailscale ${{ inputs.ts_version || github.event.inputs.ts_version || github.ref_name }}.
+            Based on Tailscale ${{ inputs.ts_version || github.event.inputs.ts_version || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || '' }}.
             Featuring Netmon Patch (ifconfig parser), auto-socket resolution, and daemon auto-start helper.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Without tags `git describe` falls back to a bare commit hash,
+          # which is not a usable package version.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
             bin/tailscale-*
             bin/tailscaled-*
             dist/*.deb
+            dist/*.pkg.tar.xz
 
   release:
     name: Create Release
@@ -80,7 +81,7 @@ jobs:
       - name: Prepare Release Assets
         run: |
           mkdir -p release_assets
-          find artifacts/ -type f \( -name "tailscale-*" -o -name "tailscaled-*" -o -name "*.deb" \) -exec cp {} release_assets/ \;
+          find artifacts/ -type f \( -name "tailscale-*" -o -name "tailscaled-*" -o -name "*.deb" -o -name "*.pkg.tar.xz" \) -exec cp {} release_assets/ \;
           # Publish checksums: remote-install.sh and tailscale-update pull these
           # assets over plain HTTPS with nothing to verify them against.
           ( cd release_assets && sha256sum ./* > SHA256SUMS )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,9 @@ jobs:
         run: |
           mkdir -p release_assets
           find artifacts/ -type f \( -name "tailscale-*" -o -name "tailscaled-*" -o -name "*.deb" -o -name "*.pkg.tar.xz" \) -exec cp {} release_assets/ \;
+          # BSD-3 clause 2 asks for the notice to travel with binary
+          # distributions; the loose binaries here are not inside a package.
+          cp LICENSE release_assets/LICENSE
           # Publish checksums: remote-install.sh and tailscale-update pull these
           # assets over plain HTTPS with nothing to verify them against.
           ( cd release_assets && sha256sum ./* > SHA256SUMS )

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # Manual trigger
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check-updates:
@@ -23,30 +23,54 @@ jobs:
       - name: Get latest upstream tag
         id: upstream
         run: |
-          UPSTREAM_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/tailscale/tailscale.git | grep -v 'pre\|beta\|rc\|{}$' | tail -n1 | sed 's/.*\///')
-          echo "tag=$UPSTREAM_TAG" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          UPSTREAM_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/tailscale/tailscale.git \
+            | grep -v 'pre\|beta\|rc\|{}$' | tail -n1 | sed 's/.*\///')
+          if [ -z "$UPSTREAM_TAG" ]; then
+            echo "Could not determine the upstream tag." >&2
+            exit 1
+          fi
+          echo "tag=$UPSTREAM_TAG" >> "$GITHUB_OUTPUT"
           echo "Found upstream tag: $UPSTREAM_TAG"
 
       - name: Get latest local release
         id: local
         run: |
-          LOCAL_RELEASE=$(curl -s "https://api.github.com/repos/${{ github.repository }}/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")' || echo "none")
+          set -euo pipefail
+          LOCAL_RELEASE=$(curl -fsS "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest" 2>/dev/null \
+            | grep -Po '"tag_name": "\K.*?(?=")' || true)
           if [ -z "$LOCAL_RELEASE" ]; then LOCAL_RELEASE="none"; fi
-          echo "tag=$LOCAL_RELEASE" >> $GITHUB_OUTPUT
+          echo "tag=$LOCAL_RELEASE" >> "$GITHUB_OUTPUT"
           echo "Found local release: $LOCAL_RELEASE"
 
       - name: Compare tags
         id: compare
+        # Interpolating ${{ }} straight into a shell body puts a value from a
+        # third-party repository into this runner's command line; passing it
+        # through env keeps it a string.
+        env:
+          UPSTREAM_TAG: ${{ steps.upstream.outputs.tag }}
+          LOCAL_TAG: ${{ steps.local.outputs.tag }}
         run: |
-          if [ "${{ steps.upstream.outputs.tag }}" != "${{ steps.local.outputs.tag }}" ]; then
-            echo "new_version=true" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          # Releases here are tagged like "v1.100.0-10" (upstream version plus a
+          # build number), so comparing them raw against upstream's "v1.100.0"
+          # never matched and rebuilt all four architectures every single night.
+          normalize() { echo "${1#v}" | sed -E 's/-[0-9]+$//'; }
+          UP_NORM=$(normalize "$UPSTREAM_TAG")
+          LOCAL_NORM=$(normalize "$LOCAL_TAG")
+          echo "Comparing upstream '$UP_NORM' against local '$LOCAL_NORM'"
+          if [ "$UP_NORM" != "$LOCAL_NORM" ]; then
+            echo "new_version=true" >> "$GITHUB_OUTPUT"
           else
-            echo "new_version=false" >> $GITHUB_OUTPUT
+            echo "new_version=false" >> "$GITHUB_OUTPUT"
           fi
 
   build:
     needs: check-updates
     if: needs.check-updates.outputs.new_version == 'true'
+    permissions:
+      contents: write
     uses: ./.github/workflows/build.yml
     with:
       ts_version: ${{ needs.check-updates.outputs.tag }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,16 @@
 Copyright (c) 2026 Tailscale Termux CLI Contributors
 All rights reserved.
 
+This license covers this project's own contributions: the build scripts, the
+packaging, the helper commands, and the patch files under patches/.
+
+The tailscale and tailscaled programs this project builds and distributes are
+Copyright (c) Tailscale Inc. & AUTHORS, licensed under the same BSD 3-Clause
+terms reproduced below. Nothing here claims copyright over that code. Binary
+distributions of this project ship Tailscale's notice alongside this one, at
+$PREFIX/share/doc/tailscale-termux/copyright, as clause 2 requires. Upstream
+source: https://github.com/tailscale/tailscale
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ tailscale up
 1. **Netmon Bypass (Android 11+)**: Intercepts interface discovery (`anet` ioctl, `/proc/net/if_inet6`, `ifconfig` fallback) to bypass Android netlink restrictions.
 2. **Userspace Networking**: Runs without Root or `/dev/net/tun` out of the box.
 3. **Automatic Socket Resolution**: Both `tailscale` and `tailscale-cli` route requests to `~/.tailscale/tailscaled.sock` without a manual `--socket` flag.
-4. **Auto-Start Daemon**: Invoking `tailscale` or `tailscale-cli` starts `tailscaled` if it is not running.
+4. **Auto-Start Daemon**: The `tailscale-cli` wrapper starts `tailscaled` if it is not running. (The bare `tailscale` binary only gets the socket path filled in — start the daemon yourself, or use the service.)
 5. **Runit (`termux-services`) Integration**: Background service management, started when a Termux session opens.
 6. **Authenticated SOCKS5 proxy**: credentials are generated for you on first start — see below.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run this single command in Termux to download and install the latest package:
 curl -fsSL https://raw.githubusercontent.com/bropines/tailscale-termux-cli/main/remote-install.sh | bash
 ```
 
-Once installed, the `tailscaled` background service is automatically enabled and started. You can immediately connect:
+Once installed, the `tailscaled` background service is enabled and started. You can immediately connect:
 
 ```bash
 tailscale up
@@ -23,11 +23,50 @@ tailscale up
 
 ## ✨ Features & Patches
 
-1. **Netmon Bypass (Android 11+)**: Intercepts interface discovery using an `ifconfig` parser to bypass Android netlink restrictions.
+1. **Netmon Bypass (Android 11+)**: Intercepts interface discovery (`anet` ioctl, `/proc/net/if_inet6`, `ifconfig` fallback) to bypass Android netlink restrictions.
 2. **Userspace Networking**: Runs without Root or `/dev/net/tun` out of the box.
-3. **Automatic Socket Resolution**: Both `tailscale` and `tailscale-cli` automatically route requests to `~/.tailscale/tailscaled.sock` without requiring manual `--socket` flags.
-4. **Auto-Start Daemon**: Invoking `tailscale` or `tailscale-cli` automatically starts the `tailscaled` daemon if it is not currently running.
-5. **Runit (`termux-services`) Integration**: Native background service management with auto-start on boot support.
+3. **Automatic Socket Resolution**: Both `tailscale` and `tailscale-cli` route requests to `~/.tailscale/tailscaled.sock` without a manual `--socket` flag.
+4. **Auto-Start Daemon**: Invoking `tailscale` or `tailscale-cli` starts `tailscaled` if it is not running.
+5. **Runit (`termux-services`) Integration**: Background service management, started when a Termux session opens.
+6. **Authenticated SOCKS5 proxy**: credentials are generated for you on first start — see below.
+
+---
+
+## 🔐 The SOCKS5 Proxy (read this once)
+
+`tailscaled` runs a SOCKS5 proxy on `127.0.0.1:1055` so you can route other apps through your tailnet.
+
+**Android's loopback interface is not isolated per app.** Any app on the device holding only the `INTERNET` permission can connect to `127.0.0.1:1055`. If the proxy were open, that app would get egress into your tailnet *as this node* — reaching private hosts, subnet routes and your exit node.
+
+So the proxy requires a username and password. They are generated on the first daemon start and stored in `~/.tailscale/socks5.env` (mode `0600`). Show them with:
+
+```bash
+tailscale-socks5
+```
+
+```
+Tailscale SOCKS5 Proxy
+======================
+Address  : 127.0.0.1:1055   (running daemon)
+Username : termux
+Password : 5f3a9c1e8b7d2046
+URL      : socks5://termux:5f3a9c1e8b7d2046@127.0.0.1:1055
+```
+
+Other useful forms:
+
+| Command | Purpose |
+|---|---|
+| `tailscale-socks5` | Show address and credentials |
+| `tailscale-socks5 --url` | Print just the proxy URL, for scripts |
+| `tailscale-socks5 --regenerate` | Issue a new password (restart the daemon to apply) |
+
+The credentials are passed to the daemon through its environment, never as command-line flags — anything on `argv` is readable by every process on the device via `/proc`.
+
+To turn the proxy off entirely, set `TS_SOCKS5=off` in `~/.tailscale/.env`.
+
+> [!WARNING]
+> `TS_SOCKS5_NO_AUTH=1` restores the old unauthenticated proxy. It exists only for clients that cannot send SOCKS5 credentials, and it reopens your tailnet to every app on the device.
 
 ---
 
@@ -52,6 +91,10 @@ You can use standard `tailscale` commands or the `tailscale-cli` wrapper interch
   ```bash
   tailscale funnel 8096
   ```
+* **Show the SOCKS5 proxy credentials**:
+  ```bash
+  tailscale-socks5
+  ```
 * **Run functional test (SOCKS5 & DNS)**:
   ```bash
   tailscale-test
@@ -67,7 +110,7 @@ The background daemon is managed via `termux-services` (runit) or helper command
   ```bash
   tailscaled-start --service=status
   ```
-* **Enable auto-start on boot & start daemon**:
+* **Enable auto-start & start daemon**:
   ```bash
   tailscaled-start --service=on
   ```
@@ -80,27 +123,46 @@ The background daemon is managed via `termux-services` (runit) or helper command
   tailscaled-log
   ```
 
+> [!NOTE]
+> "Auto-start" means **when a Termux session opens**, not at device boot. `termux-services` starts its supervisor from `$PREFIX/etc/profile.d/start-services.sh`, so after a reboot the node stays offline until you open Termux. To get closer to real boot start, install the [Termux:Boot](https://wiki.termux.com/wiki/Termux:Boot) add-on, and consider `termux-wake-lock` so Android does not doze the daemon.
+
 ---
 
 ## 🔧 Configuration (`.env`)
 
-Configure daemon settings by creating/editing `~/.tailscale/.env`. Variables are automatically loaded on start:
+Configure the daemon by creating/editing `~/.tailscale/.env`. It is read on **both** start paths — the `termux-services` service and a manual `tailscaled-start`.
 
-| Variable | Tailscaled Flag | Description |
-|----------|-----------------|-------------|
-| `TS_SOCKS5_PORT` | `--socks5-server` | Set a specific SOCKS5 port (e.g. `1055`) |
+| Variable | Effect | Description |
+|----------|--------|-------------|
+| `TS_SOCKS5_PORT` | `--socks5-server` | SOCKS5 port on `127.0.0.1` (default `1055`) |
 | `TS_SOCKS5_SERVER` | `--socks5-server` | Full address (e.g. `127.0.0.1:1055`) |
-| `TS_HTTP_PROXY` | `--outbound-http-proxy-listen` | HTTP Proxy address |
+| `TS_SOCKS5` | — | Set to `off` to disable the proxy entirely |
+| `TS_SOCKS5_USER` / `TS_SOCKS5_PASS` | proxy credentials | Override the generated pair |
+| `TS_SOCKS5_NO_AUTH` | proxy credentials | `1` disables proxy authentication (**not recommended**) |
+| `TS_HTTP_PROXY` | `--outbound-http-proxy-listen` | HTTP proxy address |
 | `TS_PORT` | `--port` | UDP port for WireGuard |
-| `TS_VERBOSE` | `--verbose` | Log verbosity level (`1`, `2`...) |
+| `TS_DNS_SERVER` | resolver | Resolver to use (default `8.8.8.8`); `system` keeps Go's default |
+| `TS_LOG_VERBOSITY` | log verbosity | `1`, `2`… (`TS_VERBOSE` is accepted as an alias) |
+| `TS_NO_LOGS_NO_SUPPORT` | log upload | `true` disables log upload to Tailscale (`TS_NO_LOGS` is an alias) |
 | `TS_EXTRA_ARGS` | (raw flags) | Additional raw flags to pass |
 
 Example `~/.tailscale/.env`:
 ```bash
 TS_SOCKS5_PORT=1055
-TS_VERBOSE=1
+TS_LOG_VERBOSITY=1
 TS_EXTRA_ARGS="--hostname=termux-node"
 ```
+
+Changes apply on the next daemon restart (`sv restart tailscaled`, or `tailscaled-stop && tailscaled-start`).
+
+---
+
+## 🔍 What the patches change about your node
+
+Worth knowing before you put this on a tailnet you do not own:
+
+* **DNS**: the binaries are built with `CGO_ENABLED=0`, so Go uses its pure-Go resolver, which wants `/etc/resolv.conf` — a file Termux does not have. The patch therefore points the resolver at `8.8.8.8:53`, meaning the daemon's lookups go to Google rather than your network's DNS. Change it with `TS_DNS_SERVER`, or set `TS_DNS_SERVER=system` to opt out.
+* **Reported identity**: the daemon reports itself to the control plane as `App=tailscale-cli`, `DeviceModel=Termux`. This avoids mobile-specific client policies. Tailnet admins relying on client type for posture rules should know this node reports as a CLI client.
 
 ---
 
@@ -109,9 +171,13 @@ TS_EXTRA_ARGS="--hostname=termux-node"
 If you have Go installed in Termux, you can build from source:
 
 ```bash
-./build.sh
 ./install.sh
 ```
+
+`build.sh` verifies after every compile that the netmon, `anet` and SOCKS5-auth patches actually made it into `tailscaled`, and fails the build if not.
+
+> [!NOTE]
+> Only `aarch64` is built as `GOOS=android`; Go requires cgo/NDK external linking for every other Android architecture, so `arm`, `i686` and `x86_64` are built as static `GOOS=linux` binaries. The patches are tagged `android || linux` so they are present in all four.
 
 ---
 
@@ -132,7 +198,20 @@ sv up tailscaled
 </details>
 
 <details>
-<summary><b>2. Shell Autocompletions not working</b></summary>
+<summary><b>2. My SOCKS5 client stopped working after an update</b></summary>
+<br>
+The proxy now requires a password. Get it with:
+
+```bash
+tailscale-socks5
+```
+
+and add the username/password to your client, or use the printed
+`socks5://user:pass@host:port` URL directly.
+</details>
+
+<details>
+<summary><b>3. Shell Autocompletions not working</b></summary>
 <br>
 Autocompletions for **Bash**, **Zsh**, and **Fish** are installed automatically. Restart your shell session or reload your shell profile to apply them.
 </details>
@@ -144,5 +223,6 @@ Autocompletions for **Bash**, **Zsh**, and **Fish** are installed automatically.
 - **IPv6 UDP Probing & Netmon Enhancements:** [@sailshen](https://github.com/sailshen) (PR #8).
 - **Patch Inspiration:** [asutorufa/tailscale](https://github.com/Asutorufa/tailscale).
 
-*Note: This project is not affiliated with Tailscale Inc.*
+The `tailscale` and `tailscaled` binaries are built from Tailscale's BSD-3-Clause source; the full notice ships in the package at `$PREFIX/share/doc/tailscale-termux/copyright`.
 
+*Note: This project is not affiliated with Tailscale Inc.*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Run this single command in Termux to download and install the latest package:
 curl -fsSL https://raw.githubusercontent.com/bropines/tailscale-termux-cli/main/remote-install.sh | bash
 ```
 
+The installer detects whether your Termux uses **dpkg** or **pacman** and fetches the matching package (`.deb` or `.pkg.tar.xz`). Releases carry a `SHA256SUMS` file if you want to verify the download by hand.
+
 Once installed, the `tailscaled` background service is enabled and started. You can immediately connect:
 
 ```bash
@@ -174,7 +176,12 @@ If you have Go installed in Termux, you can build from source:
 ./install.sh
 ```
 
-`build.sh` verifies after every compile that the netmon, `anet` and SOCKS5-auth patches actually made it into `tailscaled`, and fails the build if not.
+`install.sh` produces both a `.deb` and a `.pkg.tar.xz` in `dist/`.
+
+Two build-time guards worth knowing about:
+
+* **The upstream tarball is checksummed.** `checksums/<version>.sha256` pins the SHA-256 of Tailscale's source archive, verified before anything is unpacked, compiled or run. A version with no pin yet is recorded and reported so you can commit it; set `TS_REQUIRE_CHECKSUM=1` to make an unpinned version a hard failure instead.
+* **The binary is checked for the patches.** After every compile `build.sh` greps `tailscaled` for the netmon, `anet` and SOCKS5-auth markers and fails if any are missing. A `//go:build` tag that stops matching produces no warning anywhere, which is exactly how three architectures once shipped unpatched.
 
 > [!NOTE]
 > Only `aarch64` is built as `GOOS=android`; Go requires cgo/NDK external linking for every other Android architecture, so `arm`, `i686` and `x86_64` are built as static `GOOS=linux` binaries. The patches are tagged `android || linux` so they are present in all four.

--- a/build.sh
+++ b/build.sh
@@ -2,24 +2,32 @@
 # Tailscale Termux CLI Builder
 # Optimized for Android 11+ with ifconfig-based netmon patch and duplicate os.Args workaround.
 # Credits: Tailscale Team, asutorufa/tailscale, and Gemini CLI AI Agent.
-set -eu
+set -euo pipefail
 
 echo "Tailscale Termux CLI Builder"
 echo "=============================="
 
-# 1. Check for Go
-if ! command -v go >/dev/null 2>&1; then
-    echo "Error: Go is not installed. Please install it with 'pkg install golang' in Termux."
+# 1. Check for build tools
+MISSING=""
+for tool in go git wget tar; do
+    command -v "$tool" >/dev/null 2>&1 || MISSING="$MISSING $tool"
+done
+if [ -n "$MISSING" ]; then
+    echo "Error: missing required tools:$MISSING"
+    echo "Install them in Termux with 'pkg install golang git wget tar'."
     exit 1
 fi
 
 # 2. Determine latest stable Tailscale version
 if [ -z "${TS_VERSION:-}" ]; then
     echo "-> Fetching latest stable Tailscale version..."
-    TS_VERSION=$(git ls-remote --tags --sort="v:refname" https://github.com/tailscale/tailscale.git | grep -v 'pre\|beta\|rc\|{}$' | tail -n1 | sed 's/.*\///')
+    # pipefail is on, so a failing git ls-remote is caught here rather than
+    # silently yielding an empty string and falling through to the fallback.
+    TS_VERSION=$(git ls-remote --tags --sort="v:refname" https://github.com/tailscale/tailscale.git 2>/dev/null | grep -v 'pre\|beta\|rc\|{}$' | tail -n1 | sed 's/.*\///') || TS_VERSION=""
     if [ -z "$TS_VERSION" ]; then
-        echo "Error: Could not find latest Tailscale tag. Falling back to v1.96.5"
-        TS_VERSION="v1.96.5"
+        echo "Error: Could not find latest Tailscale tag (no network?)."
+        echo "       Set TS_VERSION explicitly, e.g. TS_VERSION=v1.100.0 ./build.sh"
+        exit 1
     fi
 fi
 
@@ -32,6 +40,7 @@ WORKDIR="$(pwd)"
 SRC_DIR="$WORKDIR/tailscale_src"
 PATCH_DIR="$WORKDIR/patches"
 OUT_DIR="$WORKDIR/bin"
+SRC_STAMP="$SRC_DIR/.ts_version"
 
 # Determine target architecture(s)
 TARGET_ARCH="${1:-}"
@@ -52,29 +61,62 @@ fi
 
 # 3. Downloading source
 echo "[1/3] Downloading Tailscale source ($DOWNLOAD_VERSION)..."
+# The cache is keyed on the version it was populated with. Without this a
+# `git pull` + rebuild happily reuses an old tree and stamps the new version
+# onto a stale binary, so `tailscale-update` then reports you are current.
+if [ -d "$SRC_DIR" ]; then
+    CACHED_VERSION=$(cat "$SRC_STAMP" 2>/dev/null || echo "unknown")
+    if [ "$CACHED_VERSION" != "$DOWNLOAD_VERSION" ]; then
+        echo "-> Cached source is $CACHED_VERSION, need $DOWNLOAD_VERSION. Removing."
+        rm -rf "$SRC_DIR"
+    else
+        echo "-> Source $CACHED_VERSION already present. Skipping download."
+    fi
+fi
+
 if [ ! -d "$SRC_DIR" ]; then
     if ! wget -qO- "https://github.com/tailscale/tailscale/archive/refs/tags/${DOWNLOAD_VERSION}.tar.gz" | tar -xz; then
         echo "Error: Failed to download or extract Tailscale source for version $DOWNLOAD_VERSION"
         exit 1
     fi
-    mv tailscale-${DOWNLOAD_VERSION#v} "$SRC_DIR"
-else
-    echo "-> Source already exists. Skipping download."
+    mv "tailscale-${DOWNLOAD_VERSION#v}" "$SRC_DIR"
+    echo "$DOWNLOAD_VERSION" > "$SRC_STAMP"
 fi
 
 # 4. Applying patches
-echo "[2/3] Applying netmon and argument patches..."
+echo "[2/3] Applying netmon, argument and SOCKS5 auth patches..."
 cp "$PATCH_DIR/fix_android_netmon.go" "$SRC_DIR/cmd/tailscaled/"
 cp "$PATCH_DIR/fix_args_android.go" "$SRC_DIR/cmd/tailscaled/"
 cp "$PATCH_DIR/fix_args_android.go" "$SRC_DIR/cmd/tailscale/"
+cp "$PATCH_DIR/fix_socks5_auth.go" "$SRC_DIR/cmd/tailscaled/"
 
 echo "-> Enabling cert endpoint on Android..."
-# Prevent duplicate replacements if build script is run multiple times
-if ! grep -q "localapi" "$SRC_DIR/ipn/localapi/cert.go" 2>/dev/null; then
-    : # Already processed or files don't have it
-fi
+# Both substitutions are idempotent: after the first pass there is no
+# "!android && " or " || android" left to match.
 sed 's/!android && //g' "$SRC_DIR/ipn/localapi/cert.go" > "$SRC_DIR/ipn/localapi/cert.go.tmp" && mv "$SRC_DIR/ipn/localapi/cert.go.tmp" "$SRC_DIR/ipn/localapi/cert.go"
 sed 's/ || android//g' "$SRC_DIR/ipn/localapi/disabled_stubs.go" > "$SRC_DIR/ipn/localapi/disabled_stubs.go.tmp" && mv "$SRC_DIR/ipn/localapi/disabled_stubs.go.tmp" "$SRC_DIR/ipn/localapi/disabled_stubs.go"
+
+# Wire the SOCKS5 credentials into the proxy server. Upstream's socks5.Server
+# already has Username/Password fields; cmd/tailscaled simply never sets them,
+# which is why --socks5-server has always listened unauthenticated.
+#
+# A failure to apply is fatal on purpose: silently shipping an open proxy is
+# exactly the outcome this guards against.
+echo "-> Wiring SOCKS5 authentication into cmd/tailscaled/proxy.go..."
+PROXY_GO="$SRC_DIR/cmd/tailscaled/proxy.go"
+if grep -q "termuxSocks5User()" "$PROXY_GO"; then
+    echo "   already wired, skipping."
+elif grep -q "Dialer: dialer.UserDial," "$PROXY_GO"; then
+    sed 's|Dialer: dialer.UserDial,|Dialer:   dialer.UserDial,\n\t\t\t\tUsername: termuxSocks5User(),\n\t\t\t\tPassword: termuxSocks5Pass(),|' \
+        "$PROXY_GO" > "$PROXY_GO.tmp" && mv "$PROXY_GO.tmp" "$PROXY_GO"
+    grep -q "termuxSocks5User()" "$PROXY_GO" || { echo "Error: SOCKS5 auth injection did not take effect."; exit 1; }
+    echo "   done."
+else
+    echo "Error: could not find the socks5.Server literal in $PROXY_GO."
+    echo "       Upstream changed cmd/tailscaled/proxy.go; update this patch step"
+    echo "       before releasing, or the proxy ships without authentication."
+    exit 1
+fi
 
 # Apply DNS manager patch / modules sync
 cd "$SRC_DIR"
@@ -87,32 +129,64 @@ go mod tidy
 echo "[3/3] Compiling binaries..."
 TAGS="ts_no_clipboard,ts_omit_taildrop,ts_omit_systray,ts_omit_kube,ts_omit_aws,ts_omit_bird,ts_omit_desktop_sessions,ts_omit_networkmanager,ts_omit_sdnotify,ts_omit_ssh"
 
+# Fail the build if a patch silently dropped out of the binary.
+#
+# Three of the four published architectures once shipped for months without
+# the netmon patch because a build tag stopped matching -- a change that
+# produces no warning anywhere. Checking the artifact itself is the only way
+# to notice.
+verify_patched() {
+    local arch="$1" bin="$2" missing=""
+    grep -aq "\[Termux\]" "$bin" || missing="$missing netmon"
+    grep -aq "wlynxg/anet" "$bin" || missing="$missing anet"
+    grep -aq "TS_SOCKS5_USER" "$bin" || missing="$missing socks5-auth"
+    if [ -n "$missing" ]; then
+        echo "Error: $arch/tailscaled is missing patches:$missing"
+        echo "       Refusing to publish an unpatched binary. Check the"
+        echo "       //go:build tags in patches/ against GOOS for this target."
+        return 1
+    fi
+    echo "-> $arch: netmon, anet and SOCKS5 auth patches verified in binary."
+}
+
+# Why the two build profiles below:
+#
+#   GOOS=android requires external (cgo) linking on every architecture except
+#   arm64 -- `go build` refuses outright with "android/amd64 requires external
+#   (cgo) linking". Cross-compiling those would mean shipping an Android NDK
+#   toolchain, so they are built as GOOS=linux instead.
+#
+#   That is only safe because the patches are tagged `android || linux`; when
+#   they were tagged `android` alone, these three architectures silently
+#   shipped without the netmon patch that is the whole point of this project.
+#   The verify_patched check below is what keeps that from happening again.
+#
+#   -buildmode=pie is likewise arm64-only. With CGO_ENABLED=0 a PIE build for
+#   linux/amd64 comes out as a dynamic ELF with .interp=/lib64/ld-linux-x86-64.so.2,
+#   a glibc loader Android does not have, so the binary cannot start at all.
+#   Without PIE the same build is a static executable that runs fine.
 build_for_arch() {
     local arch="$1"
     local goarch=""
     local goarm=""
     local goos="linux"
-    local build_mode_arg="-buildmode=pie"
+    local build_mode_arg=""
 
     case "$arch" in
         aarch64)
             goarch="arm64"
             goos="android"
+            build_mode_arg="-buildmode=pie"
             ;;
         arm)
             goarch="arm"
             goarm="7"
-            goos="linux"
-            build_mode_arg=""
             ;;
         i686)
             goarch="386"
-            goos="linux"
-            build_mode_arg=""
             ;;
         x86_64)
             goarch="amd64"
-            goos="linux"
             ;;
         *)
             echo "Error: Unknown target architecture '$arch'"
@@ -149,16 +223,36 @@ build_for_arch() {
     # Compile tailscaled daemon
     go build "${build_args[@]}" -o "$arch_out_dir/tailscaled" ./cmd/tailscaled
 
+    verify_patched "$arch" "$arch_out_dir/tailscaled" || return 1
+
+    # Record what these binaries were built from so build_deb.sh can tell a
+    # stale cache from a current one.
+    echo "$DOWNLOAD_VERSION" > "$arch_out_dir/.ts_version"
+
     # Copy to root bin folder with architecture suffixes for release compatibility
     cp "$arch_out_dir/tailscale" "$OUT_DIR/tailscale-$arch"
     cp "$arch_out_dir/tailscaled" "$OUT_DIR/tailscaled-$arch"
 }
 
 if [ "$TARGET_ARCH" = "all" ]; then
-    for arch in aarch64 arm i686 x86_64; do
+    ARCHES=(aarch64 arm i686 x86_64)
+    PIDS=()
+    for arch in "${ARCHES[@]}"; do
         build_for_arch "$arch" &
+        PIDS+=("$!")
     done
-    wait
+    # A bare `wait` always returns 0, so failures in these background jobs used
+    # to be reported as "Build complete!".
+    FAILED=""
+    for i in "${!PIDS[@]}"; do
+        if ! wait "${PIDS[$i]}"; then
+            FAILED="$FAILED ${ARCHES[$i]}"
+        fi
+    done
+    if [ -n "$FAILED" ]; then
+        echo "Error: build failed for:$FAILED"
+        exit 1
+    fi
 else
     build_for_arch "$TARGET_ARCH"
 fi

--- a/build.sh
+++ b/build.sh
@@ -9,12 +9,12 @@ echo "=============================="
 
 # 1. Check for build tools
 MISSING=""
-for tool in go git wget tar; do
+for tool in go git wget tar sha256sum; do
     command -v "$tool" >/dev/null 2>&1 || MISSING="$MISSING $tool"
 done
 if [ -n "$MISSING" ]; then
     echo "Error: missing required tools:$MISSING"
-    echo "Install them in Termux with 'pkg install golang git wget tar'."
+    echo "Install them in Termux with 'pkg install golang git wget tar coreutils'."
     exit 1
 fi
 
@@ -41,6 +41,7 @@ SRC_DIR="$WORKDIR/tailscale_src"
 PATCH_DIR="$WORKDIR/patches"
 OUT_DIR="$WORKDIR/bin"
 SRC_STAMP="$SRC_DIR/.ts_version"
+CHECKSUM_DIR="$WORKDIR/checksums"
 
 # Determine target architecture(s)
 TARGET_ARCH="${1:-}"
@@ -75,11 +76,48 @@ if [ -d "$SRC_DIR" ]; then
 fi
 
 if [ ! -d "$SRC_DIR" ]; then
-    if ! wget -qO- "https://github.com/tailscale/tailscale/archive/refs/tags/${DOWNLOAD_VERSION}.tar.gz" | tar -xz; then
-        echo "Error: Failed to download or extract Tailscale source for version $DOWNLOAD_VERSION"
+    # Download to a file rather than piping straight into tar, so the archive
+    # can be checksummed before any of its contents are unpacked, compiled and
+    # (for shell completions) executed on this machine.
+    TARBALL="$WORKDIR/.tailscale-${DOWNLOAD_VERSION}.tar.gz"
+    if ! wget -q -O "$TARBALL" "https://github.com/tailscale/tailscale/archive/refs/tags/${DOWNLOAD_VERSION}.tar.gz"; then
+        rm -f "$TARBALL"
+        echo "Error: Failed to download Tailscale source for version $DOWNLOAD_VERSION"
         exit 1
     fi
-    mv "tailscale-${DOWNLOAD_VERSION#v}" "$SRC_DIR"
+
+    ACTUAL_SHA=$(sha256sum "$TARBALL" | cut -d' ' -f1)
+    EXPECTED_FILE="$CHECKSUM_DIR/${DOWNLOAD_VERSION}.sha256"
+    if [ -f "$EXPECTED_FILE" ]; then
+        EXPECTED_SHA=$(cut -d' ' -f1 < "$EXPECTED_FILE")
+        if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            rm -f "$TARBALL"
+            echo "Error: checksum mismatch for Tailscale $DOWNLOAD_VERSION."
+            echo "       expected: $EXPECTED_SHA"
+            echo "       actual:   $ACTUAL_SHA"
+            echo "       Refusing to build. A release tag should never change contents."
+            exit 1
+        fi
+        echo "-> Source checksum verified against $EXPECTED_FILE"
+    elif [ -n "${TS_REQUIRE_CHECKSUM:-}" ]; then
+        rm -f "$TARBALL"
+        echo "Error: no pinned checksum for $DOWNLOAD_VERSION and TS_REQUIRE_CHECKSUM is set."
+        echo "       Record it with: echo '$ACTUAL_SHA  tailscale-$DOWNLOAD_VERSION.tar.gz' > $EXPECTED_FILE"
+        exit 1
+    else
+        mkdir -p "$CHECKSUM_DIR"
+        echo "$ACTUAL_SHA  tailscale-${DOWNLOAD_VERSION}.tar.gz" > "$EXPECTED_FILE"
+        echo "-> No pinned checksum for $DOWNLOAD_VERSION; recorded $ACTUAL_SHA"
+        echo "   Commit $EXPECTED_FILE so later builds verify against it."
+    fi
+
+    if ! tar -xzf "$TARBALL" -C "$WORKDIR"; then
+        rm -f "$TARBALL"
+        echo "Error: Failed to extract Tailscale source for version $DOWNLOAD_VERSION"
+        exit 1
+    fi
+    rm -f "$TARBALL"
+    mv "$WORKDIR/tailscale-${DOWNLOAD_VERSION#v}" "$SRC_DIR"
     echo "$DOWNLOAD_VERSION" > "$SRC_STAMP"
 fi
 

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -10,17 +10,30 @@ if [ -z "${TS_VERSION:-}" ]; then
     # Try to find from git tag or default
     TS_VERSION=$(git describe --tags --always 2>/dev/null || echo "1.100.0")
 fi
-# Hand the same version down to build.sh, so the source it downloads and the
-# version stamped on the package cannot disagree.
-export TS_VERSION
 # Clean version string for debian (replace starting 'v' if present, replace dashes with tildes)
 DEB_VERSION=$(echo "$TS_VERSION" | sed 's/^v//' | tr '-' '.')
-# The upstream source version these binaries must have been built from.
-SRC_VERSION=$(echo "$TS_VERSION" | sed -E 's/(-[0-9]+)$//')
-case "$SRC_VERSION" in
-    v*) ;;
-    *) SRC_VERSION="v$SRC_VERSION" ;;
-esac
+
+# The upstream source version these binaries must be built from.
+#
+# TS_VERSION doubles as this project's package version, and the two are not
+# always the same thing: `git describe --always` in a shallow CI checkout
+# returns a bare commit hash, which makes a fine package version but is not a
+# tag build.sh can download.
+if printf '%s' "$TS_VERSION" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$'; then
+    SRC_VERSION=$(echo "$TS_VERSION" | sed -E 's/(-[0-9]+)$//')
+    case "$SRC_VERSION" in
+        v*) ;;
+        *) SRC_VERSION="v$SRC_VERSION" ;;
+    esac
+    # Hand it down so the source build.sh downloads and the version stamped on
+    # the package cannot disagree.
+    export TS_VERSION
+else
+    echo "-> Package version '$TS_VERSION' is not an upstream release tag;"
+    echo "   build.sh will resolve the latest Tailscale version itself."
+    SRC_VERSION=""
+    unset TS_VERSION
+fi
 
 TARGET_ARCH="${1:-}"
 if [ -z "$TARGET_ARCH" ]; then
@@ -48,6 +61,8 @@ binaries_are_current() {
     local arch="$1"
     [ -f "$BIN_DIR/$arch/tailscale" ] || return 1
     [ -f "$BIN_DIR/$arch/tailscaled" ] || return 1
+    # With no pinned upstream version there is nothing to compare against.
+    [ -n "$SRC_VERSION" ] || return 0
     # Without this check a stale binary gets packaged under a fresh version
     # number, and tailscale-update then cheerfully reports you are up to date.
     [ "$(cat "$BIN_DIR/$arch/.ts_version" 2>/dev/null || echo unknown)" = "$SRC_VERSION" ]

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -50,6 +50,61 @@ binaries_are_current() {
     [ "$(cat "$BIN_DIR/$arch/.ts_version" 2>/dev/null || echo unknown)" = "$SRC_VERSION" ]
 }
 
+# Emit a pacman package from the same staged payload as the .deb.
+#
+# Termux ships a pacman-based variant (issue #9), whose packages are a tar
+# archive of the filesystem plus a .PKGINFO metadata file and an optional
+# .INSTALL scriptlet, both of which must come first in the archive.
+build_pacman_from_stage() {
+    local pkg_dir="$1" arch="$2"
+    local out="$DIST_DIR/tailscale-termux-${DEB_VERSION}-1-${arch}.pkg.tar.xz"
+    local stage="$DIST_DIR/.pacman_${arch}"
+
+    rm -rf "$stage"
+    mkdir -p "$stage"
+    # Same payload, minus the Debian-only control directory.
+    ( cd "$pkg_dir" && tar -cf - --exclude=./DEBIAN data ) | ( cd "$stage" && tar -xf - )
+
+    local size
+    size=$(du -sb "$stage" | cut -f1)
+
+    cat > "$stage/.PKGINFO" << PKGINFO
+pkgname = tailscale-termux
+pkgbase = tailscale-termux
+pkgver = ${DEB_VERSION}-1
+pkgdesc = Patched Tailscale CLI for Termux on Android 11+
+url = https://github.com/bropines/tailscale-termux-cli
+builddate = $(date +%s)
+packager = bropines <https://github.com/bropines/tailscale-termux-cli>
+size = $size
+arch = $arch
+license = BSD-3-Clause
+conflict = tailscale
+replaces = tailscale
+depend = termux-services
+depend = curl
+depend = wget
+depend = procps
+depend = coreutils
+PKGINFO
+
+    # pacman's equivalent of postinst; both call the same on-device script.
+    cat > "$stage/.INSTALL" << 'INSTALL'
+post_install() {
+    sh "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/post-install.sh" install || true
+}
+
+post_upgrade() {
+    sh "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/post-install.sh" upgrade || true
+}
+INSTALL
+
+    # .PKGINFO and .INSTALL must precede the payload in the archive.
+    ( cd "$stage" && tar -cf - .PKGINFO .INSTALL data | xz -T0 -c > "$out" )
+    rm -rf "$stage"
+    echo "-> Pacman package created successfully: $out"
+}
+
 build_deb_for_arch() {
     local arch="$1"
     local deb_arch=""
@@ -118,15 +173,28 @@ EOF
     mkdir -p "$bash_comp_dir" "$zsh_comp_dir" "$fish_comp_dir"
 
     echo "-> Generating shell completions..."
-    (
-        cd "$SRC_DIR"
-        # Build host-native tailscale binary once to generate completions quickly
-        go build -o "$WORKDIR/tailscale-host-$arch" ./cmd/tailscale
-    )
-    "$WORKDIR/tailscale-host-$arch" completion bash > "$bash_comp_dir/tailscale"
-    "$WORKDIR/tailscale-host-$arch" completion zsh > "$zsh_comp_dir/_tailscale"
-    "$WORKDIR/tailscale-host-$arch" completion fish > "$fish_comp_dir/tailscale.fish"
-    rm "$WORKDIR/tailscale-host-$arch"
+    # Prefer the binary we just built. On a Termux install the target is the
+    # host, so this both skips a second compile and avoids building *and*
+    # running a second copy of freshly downloaded upstream code on the
+    # packaging machine (which, for install.sh, is the user's phone).
+    local comp_bin="$BIN_DIR/$arch/tailscale"
+    local host_built=""
+    if ! "$comp_bin" completion bash > "$bash_comp_dir/tailscale" 2>/dev/null || [ ! -s "$bash_comp_dir/tailscale" ]; then
+        echo "   (target binary is not runnable here; building a host one)"
+        (
+            cd "$SRC_DIR"
+            go build -o "$WORKDIR/tailscale-host-$arch" ./cmd/tailscale
+        )
+        comp_bin="$WORKDIR/tailscale-host-$arch"
+        host_built=1
+        "$comp_bin" completion bash > "$bash_comp_dir/tailscale"
+    fi
+    "$comp_bin" completion zsh > "$zsh_comp_dir/_tailscale"
+    "$comp_bin" completion fish > "$fish_comp_dir/tailscale.fish"
+    # Not `[ ... ] && rm`: a false test would return 1 and trip `set -e`.
+    if [ -n "$host_built" ]; then
+        rm -f "$comp_bin"
+    fi
 
     # Register tailscale-cli shell integrations
     echo "complete -F _tailscale tailscale-cli" > "$bash_comp_dir/tailscale-cli"
@@ -794,24 +862,12 @@ Homepage: https://github.com/bropines/tailscale-termux-cli
 Description: Patched version of Tailscale CLI for Termux on Android 11+
 EOF
 
-    # 4.5 Generate Debian Postinst Script
-    cat << 'EOF' > "$pkg_dir/DEBIAN/postinst"
-#!/data/data/com.termux/files/usr/bin/sh
-set -e
-
-PREFIX="/data/data/com.termux/files/usr"
-TS_HOME="${HOME:-/data/data/com.termux/files/home}/.tailscale"
-
-# svlogd exits fatally if its log directory is missing, which leaves runsv
-# restarting the log service forever. Never fatal here though: under `set -e` a
-# failed mkdir would abort postinst and leave the package unconfigured.
-mkdir -p "$PREFIX/var/log/tailscaled" 2>/dev/null || true
-
-# dpkg passes the previously installed version as $2 on an upgrade, and
-# nothing on a fresh install. Only upgraders need warning about the change.
-if [ -n "${2:-}" ] && mkdir -p "$TS_HOME" 2>/dev/null; then
-    NOTICE="$TS_HOME/UPGRADE_NOTICE"
-    cat > "$NOTICE" << 'NOTICE_EOF'
+    # 4.5 Post-install logic, shared by the .deb and the pacman package.
+    # One implementation on the device rather than the same script written
+    # twice into two different packaging formats.
+    local notice_dir="$pkg_dir/data/data/com.termux/files/usr/share/tailscale-termux"
+    mkdir -p "$notice_dir"
+    cat << 'EOF' > "$notice_dir/upgrade-notice.txt"
 ==========================================================
  IMPORTANT: the SOCKS5 proxy now requires a password
 ==========================================================
@@ -841,14 +897,22 @@ app on the device.
 
 Delete this file to dismiss: rm ~/.tailscale/UPGRADE_NOTICE
 ==========================================================
-NOTICE_EOF
-    chmod 644 "$NOTICE" 2>/dev/null || true
-    # Let tailscale-cli show it again on first use: dpkg's output scrolls past.
-    rm -f "$TS_HOME/.upgrade_notice_shown"
-    echo ""
-    cat "$NOTICE"
-    echo ""
-fi
+EOF
+    chmod 644 "$notice_dir/upgrade-notice.txt"
+
+    cat << 'EOF' > "$libexec_dir/post-install.sh"
+#!/data/data/com.termux/files/usr/bin/sh
+# Shared post-install steps. $1 is "install" or "upgrade".
+# Nothing here may fail the packaging transaction, so every step is guarded.
+set -e
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+TS_HOME="${HOME:-/data/data/com.termux/files/home}/.tailscale"
+MODE="${1:-install}"
+
+# svlogd exits fatally if its log directory is missing, which leaves runsv
+# restarting the log service forever.
+mkdir -p "$PREFIX/var/log/tailscaled" 2>/dev/null || true
 
 if command -v termux-fix-shebang >/dev/null 2>&1; then
     termux-fix-shebang "$PREFIX/bin/tailscaled-start" \
@@ -861,6 +925,18 @@ if command -v termux-fix-shebang >/dev/null 2>&1; then
                        "$PREFIX/var/service/tailscaled/run" 2>/dev/null || true
 fi
 
+# Only upgraders need warning that the proxy stopped accepting anonymous
+# clients; a fresh install never had the old behaviour.
+NOTICE_SRC="$PREFIX/share/tailscale-termux/upgrade-notice.txt"
+if [ "$MODE" = "upgrade" ] && [ -f "$NOTICE_SRC" ] && mkdir -p "$TS_HOME" 2>/dev/null; then
+    cp "$NOTICE_SRC" "$TS_HOME/UPGRADE_NOTICE" 2>/dev/null || true
+    # Let tailscale-cli repeat it once: package manager output scrolls past.
+    rm -f "$TS_HOME/.upgrade_notice_shown"
+    echo ""
+    cat "$TS_HOME/UPGRADE_NOTICE" 2>/dev/null || true
+    echo ""
+fi
+
 if command -v sv-enable >/dev/null 2>&1; then
     sv-enable tailscaled 2>/dev/null || true
     sv up tailscaled 2>/dev/null || true
@@ -868,9 +944,22 @@ fi
 
 exit 0
 EOF
+    chmod 755 "$libexec_dir/post-install.sh"
+
+    # 4.6 Debian maintainer script
+    cat << 'EOF' > "$pkg_dir/DEBIAN/postinst"
+#!/data/data/com.termux/files/usr/bin/sh
+set -e
+PREFIX="/data/data/com.termux/files/usr"
+# dpkg passes the previously installed version as $2 on an upgrade,
+# and nothing on a fresh install.
+if [ -n "${2:-}" ]; then MODE=upgrade; else MODE=install; fi
+sh "$PREFIX/libexec/tailscale-termux/post-install.sh" "$MODE" || true
+exit 0
+EOF
     chmod 755 "$pkg_dir/DEBIAN/postinst"
 
-    # 4.6 Fix shebangs for Termux environment
+    # 4.7 Fix shebangs for Termux environment
     if command -v termux-fix-shebang >/dev/null 2>&1; then
         echo "-> Fixing script shebangs for Termux..."
         termux-fix-shebang "$usr_bin_dir"/* 2>/dev/null || true
@@ -880,6 +969,14 @@ EOF
     echo "-> Compressing package with dpkg-deb (xz)..."
     dpkg-deb -Zxz --build "$pkg_dir"
     echo "-> Package created successfully: ${pkg_dir}.deb"
+
+    # 6. Build the pacman package for Termux's pacman variant (issue #9)
+    if command -v xz >/dev/null 2>&1; then
+        echo "-> Building pacman package..."
+        build_pacman_from_stage "$pkg_dir" "$arch"
+    else
+        echo "-> xz not found; skipping the pacman package."
+    fi
 }
 
 # Ensure all required binaries are built before packaging to avoid race conditions

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -12,6 +12,16 @@ if [ -z "${TS_VERSION:-}" ]; then
 fi
 # Clean version string for debian (replace starting 'v' if present, replace dashes with tildes)
 DEB_VERSION=$(echo "$TS_VERSION" | sed 's/^v//' | tr '-' '.')
+# Both dpkg and pacman require a version starting with a digit. `git describe
+# --tags --always` returns a bare commit hash when the clone has no tags, as a
+# shallow CI checkout does, and dpkg-deb rejects that outright.
+case "$DEB_VERSION" in
+    [0-9]*) ;;
+    *)
+        DEB_VERSION="0.0.0.g$DEB_VERSION"
+        echo "-> Version '$TS_VERSION' is not usable as a package version; using $DEB_VERSION"
+        ;;
+esac
 
 # The upstream source version these binaries must be built from.
 #

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -871,7 +871,15 @@ fi
 
 echo "New version available: $LATEST_TAG (Current: $CURRENT_VERSION)"
 echo "Updating via remote installer..."
-curl -fsSL "https://raw.githubusercontent.com/$REPO/main/remote-install.sh" | bash
+# Fetch the installer from the release tag, not from main. Pulling main means
+# someone who installed a reviewed version later runs whatever is on the
+# default branch at update time.
+INSTALLER="https://raw.githubusercontent.com/$REPO/$LATEST_TAG/remote-install.sh"
+if ! curl -fsSL "$INSTALLER" -o /dev/null 2>/dev/null; then
+    echo "Note: no installer at tag $LATEST_TAG; falling back to main."
+    INSTALLER="https://raw.githubusercontent.com/$REPO/main/remote-install.sh"
+fi
+curl -fsSL "$INSTALLER" | bash
 EOF
     chmod +x "$helper_update"
 

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -10,6 +10,9 @@ if [ -z "${TS_VERSION:-}" ]; then
     # Try to find from git tag or default
     TS_VERSION=$(git describe --tags --always 2>/dev/null || echo "1.100.0")
 fi
+# Hand the same version down to build.sh, so the source it downloads and the
+# version stamped on the package cannot disagree.
+export TS_VERSION
 # Clean version string for debian (replace starting 'v' if present, replace dashes with tildes)
 DEB_VERSION=$(echo "$TS_VERSION" | sed 's/^v//' | tr '-' '.')
 # The upstream source version these binaries must have been built from.

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tailscale Termux CLI Package Builder
-set -eu
+set -euo pipefail
 
 echo "Tailscale Termux Debian Package Builder"
 echo "======================================="
@@ -12,6 +12,12 @@ if [ -z "${TS_VERSION:-}" ]; then
 fi
 # Clean version string for debian (replace starting 'v' if present, replace dashes with tildes)
 DEB_VERSION=$(echo "$TS_VERSION" | sed 's/^v//' | tr '-' '.')
+# The upstream source version these binaries must have been built from.
+SRC_VERSION=$(echo "$TS_VERSION" | sed -E 's/(-[0-9]+)$//')
+case "$SRC_VERSION" in
+    v*) ;;
+    *) SRC_VERSION="v$SRC_VERSION" ;;
+esac
 
 TARGET_ARCH="${1:-}"
 if [ -z "$TARGET_ARCH" ]; then
@@ -34,6 +40,16 @@ DIST_DIR="$WORKDIR/dist"
 BIN_DIR="$WORKDIR/bin"
 SRC_DIR="$WORKDIR/tailscale_src"
 
+# Are the cached binaries for $1 current for $SRC_VERSION?
+binaries_are_current() {
+    local arch="$1"
+    [ -f "$BIN_DIR/$arch/tailscale" ] || return 1
+    [ -f "$BIN_DIR/$arch/tailscaled" ] || return 1
+    # Without this check a stale binary gets packaged under a fresh version
+    # number, and tailscale-update then cheerfully reports you are up to date.
+    [ "$(cat "$BIN_DIR/$arch/.ts_version" 2>/dev/null || echo unknown)" = "$SRC_VERSION" ]
+}
+
 build_deb_for_arch() {
     local arch="$1"
     local deb_arch=""
@@ -51,9 +67,9 @@ build_deb_for_arch() {
 
     echo "-> Preparing .deb package for $arch (version: $DEB_VERSION)..."
 
-    # Verify binaries exist, if not, build them
-    if [ ! -f "$BIN_DIR/$arch/tailscale" ] || [ ! -f "$BIN_DIR/$arch/tailscaled" ]; then
-        echo "Binaries for $arch not found. Building them first..."
+    # Verify binaries exist and match the requested source version
+    if ! binaries_are_current "$arch"; then
+        echo "Binaries for $arch missing or stale. Building them first..."
         ./build.sh "$arch"
     fi
 
@@ -61,12 +77,14 @@ build_deb_for_arch() {
     local pkg_dir="$DIST_DIR/tailscale-termux_${DEB_VERSION}_${deb_arch}"
     local usr_bin_dir="$pkg_dir/data/data/com.termux/files/usr/bin"
     local service_dir="$pkg_dir/data/data/com.termux/files/usr/var/service/tailscaled"
+    local doc_dir="$pkg_dir/data/data/com.termux/files/usr/share/doc/tailscale-termux"
 
     # Clean previous build
     rm -rf "$pkg_dir"
     mkdir -p "$usr_bin_dir"
     mkdir -p "$service_dir/log"
     mkdir -p "$pkg_dir/DEBIAN"
+    mkdir -p "$doc_dir"
 
     # 1. Copy main binaries
     cp "$BIN_DIR/$arch/tailscale" "$usr_bin_dir/tailscale"
@@ -80,10 +98,14 @@ build_deb_for_arch() {
     # Create 'down' file so runit does not auto-start the service upon package installation
     touch "$service_dir/down"
 
-    # Log service run script
+    # Log service run script.
+    # svlogd does not create its own log directory and exits fatally if it
+    # cannot open one, which puts runsv into a restart loop.
     cat << 'EOF' > "$service_dir/log/run"
 #!/data/data/com.termux/files/usr/bin/sh
-exec svlogd -tt /data/data/com.termux/files/usr/var/log/tailscaled
+LOGDIR="${PREFIX:-/data/data/com.termux/files/usr}/var/log/tailscaled"
+mkdir -p "$LOGDIR"
+exec svlogd -tt "$LOGDIR"
 EOF
     chmod +x "$service_dir/log/run"
 
@@ -96,24 +118,42 @@ EOF
     mkdir -p "$bash_comp_dir" "$zsh_comp_dir" "$fish_comp_dir"
 
     echo "-> Generating shell completions..."
-    cd "$SRC_DIR"
-    # Build host-native tailscale binary once to generate completions quickly
-    go build -o "$WORKDIR/tailscale-host-$arch" ./cmd/tailscale
+    (
+        cd "$SRC_DIR"
+        # Build host-native tailscale binary once to generate completions quickly
+        go build -o "$WORKDIR/tailscale-host-$arch" ./cmd/tailscale
+    )
     "$WORKDIR/tailscale-host-$arch" completion bash > "$bash_comp_dir/tailscale"
     "$WORKDIR/tailscale-host-$arch" completion zsh > "$zsh_comp_dir/_tailscale"
     "$WORKDIR/tailscale-host-$arch" completion fish > "$fish_comp_dir/tailscale.fish"
     rm "$WORKDIR/tailscale-host-$arch"
-    cd "$WORKDIR"
 
     # Register tailscale-cli shell integrations
     echo "complete -F _tailscale tailscale-cli" > "$bash_comp_dir/tailscale-cli"
-    
+
     cat << 'EOF' > "$zsh_comp_dir/_tailscale-cli"
 #compdef tailscale-cli
 compdef tailscale-cli=tailscale
 EOF
 
     echo "complete -c tailscale-cli -w tailscale" > "$fish_comp_dir/tailscale-cli.fish"
+
+    # 2.6 Copyright notice.
+    # Almost everything shipped here is Tailscale's BSD-3 code, whose clause 2
+    # requires reproducing the notice in binary distributions.
+    cp "$WORKDIR/LICENSE" "$doc_dir/copyright"
+    if [ -f "$SRC_DIR/LICENSE" ]; then
+        {
+            echo
+            echo "----------------------------------------------------------------"
+            echo "The tailscale and tailscaled binaries in this package are built"
+            echo "from Tailscale's source (https://github.com/tailscale/tailscale),"
+            echo "distributed under the following license:"
+            echo "----------------------------------------------------------------"
+            echo
+            cat "$SRC_DIR/LICENSE"
+        } >> "$doc_dir/copyright"
+    fi
 
     # 3. Create helper scripts in bin
     local helper_start="$usr_bin_dir/tailscaled-start"
@@ -122,21 +162,90 @@ EOF
     local helper_cli="$usr_bin_dir/tailscale-cli"
     local helper_test="$usr_bin_dir/tailscale-test"
     local helper_update="$usr_bin_dir/tailscale-update"
+    local helper_socks="$usr_bin_dir/tailscale-socks5"
 
-    # Helper: tailscaled-start
-    cat << 'EOF' > "$helper_start"
-#!/data/data/com.termux/files/usr/bin/env bash
-# Helper script to start tailscaled in Termux
-set -eu
+    # Shared library sourced by every helper, so the daemon is located the same
+    # way everywhere instead of five slightly different pgrep patterns.
+    local libexec_dir="$pkg_dir/data/data/com.termux/files/usr/libexec/tailscale-termux"
+    mkdir -p "$libexec_dir"
+    cat << 'EOF' > "$libexec_dir/common.sh"
+# shellcheck shell=bash
+# Shared helpers for the tailscale-termux scripts.
 
 STATE_DIR="$HOME/.tailscale"
 LOG_FILE="$STATE_DIR/tailscaled.log"
 SOCKET="$STATE_DIR/tailscaled.sock"
 ENV_FILE="$STATE_DIR/.env"
+CRED_FILE="$STATE_DIR/socks5.env"
 SOCKS_ADDR_FILE="$STATE_DIR/socks_addr"
 BIN_DIR="${PREFIX:-/data/data/com.termux/files/usr}/bin"
+SVLOG_DIR="${PREFIX:-/data/data/com.termux/files/usr}/var/log/tailscaled"
 
-# Help message
+# PIDs of tailscaled daemons using our state directory.
+#
+# Matching on the process name rather than `pgrep -f tailscaled` matters twice
+# over: the old pattern matched this helper's own cmdline (so "already running"
+# fired when nothing was), and it matched runsv/svlogd/tail as well.
+daemon_pids() {
+    local pid found=""
+    for pid in $(pgrep -x tailscaled 2>/dev/null || true); do
+        if [ -r "/proc/$pid/cmdline" ]; then
+            if tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -q -- "--statedir=$STATE_DIR"; then
+                found="$found $pid"
+            fi
+        else
+            found="$found $pid"
+        fi
+    done
+    printf '%s' "${found# }"
+}
+
+daemon_running() {
+    [ -n "$(daemon_pids)" ]
+}
+
+# Is tailscaled managed by termux-services right now?
+service_present() {
+    command -v sv >/dev/null 2>&1 &&
+        [ -d "${PREFIX:-/data/data/com.termux/files/usr}/var/service/tailscaled" ]
+}
+
+# The SOCKS5 address the running daemon actually listens on, read from its
+# cmdline. The socks_addr file is only a fallback: it goes stale whenever the
+# daemon is restarted by another path.
+live_socks_addr() {
+    local pid cmd
+    for pid in $(daemon_pids); do
+        cmd=$(tr '\0' '\n' < "/proc/$pid/cmdline" 2>/dev/null || true)
+        printf '%s\n' "$cmd" | sed -n 's/^--socks5-server=//p' | head -n1
+        return 0
+    done
+    return 1
+}
+
+load_credentials() {
+    if [ -f "$CRED_FILE" ]; then
+        set -a
+        # shellcheck disable=SC1090
+        . "$CRED_FILE"
+        set +a
+    fi
+}
+EOF
+    chmod 644 "$libexec_dir/common.sh"
+
+    # Helper: tailscaled-start
+    cat << 'EOF' > "$helper_start"
+#!/data/data/com.termux/files/usr/bin/env bash
+# Helper script to start tailscaled in Termux.
+#
+# This is the single place where tailscaled's flags are assembled. The
+# termux-services run script execs this with --foreground, so the service and
+# the manual path cannot drift apart (and ~/.tailscale/.env applies to both).
+set -euo pipefail
+
+. "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/common.sh"
+
 show_help() {
     echo "Tailscale Termux Start Helper"
     echo "============================="
@@ -146,9 +255,12 @@ show_help() {
     echo "  --service=on      Enable tailscaled auto-start via termux-services"
     echo "  --service=off     Disable tailscaled auto-start via termux-services"
     echo "  --service=status  Check the termux-services status of tailscaled"
+    echo "  --foreground      Run in the foreground (used by termux-services)"
     echo "  --help, -h        Show this help message"
     echo ""
     echo "Any other flags will be passed directly to the tailscaled daemon."
+    echo "Configuration lives in $ENV_FILE; see 'tailscale-socks5' for the"
+    echo "generated SOCKS5 credentials."
 }
 
 # Check for service control arguments
@@ -190,67 +302,187 @@ if [ $# -gt 0 ]; then
 fi
 
 mkdir -p "$STATE_DIR"
-if pgrep -f "tailscaled.*$STATE_DIR" > /dev/null; then
-    echo "tailscaled is already running."
+
+FOREGROUND=0
+USER_ARGS=()
+for arg in "$@"; do
+    if [ "$arg" = "--foreground" ]; then
+        FOREGROUND=1
+    else
+        USER_ARGS+=("$arg")
+    fi
+done
+
+# In foreground mode runit owns the lifecycle: bailing out with 0 here would
+# make runsv respawn us in a tight loop, so let tailscaled fail on the socket.
+if [ "$FOREGROUND" -eq 0 ] && daemon_running; then
+    echo "tailscaled is already running (pid $(daemon_pids))."
     exit 0
 fi
 
 if [ -f "$ENV_FILE" ]; then
-    set -a; source "$ENV_FILE"; set +a
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
 fi
 
-USER_ARGS=("$@")
-FINAL_ARGS=()
-SOCKS_VAL=""
-
 has_flag() {
-    local pattern="$1"
-    for arg in "${USER_ARGS[@]}"; do
-        if [[ "$arg" == "$pattern"* ]]; then
-            if [[ "$arg" == *"="* ]]; then SOCKS_VAL="${arg#*=}"; else SOCKS_VAL="NEXT"; fi
+    local pattern="$1" arg
+    for arg in ${USER_ARGS[@]+"${USER_ARGS[@]}"}; do
+        [ "$arg" = "$pattern" ] && return 0
+        [ "${arg#"$pattern"=}" != "$arg" ] && return 0
+    done
+    return 1
+}
+
+# Value of "--flag=value" or "--flag value" from USER_ARGS.
+flag_value() {
+    local pattern="$1" i arg
+    for ((i = 0; i < ${#USER_ARGS[@]}; i++)); do
+        arg="${USER_ARGS[i]}"
+        if [ "${arg#"$pattern"=}" != "$arg" ]; then
+            printf '%s' "${arg#"$pattern"=}"
             return 0
+        fi
+        if [ "$arg" = "$pattern" ]; then
+            # Bounds check: `tailscaled-start --socks5-server` with no value
+            # used to abort with "USER_ARGS[i+1]: unbound variable".
+            if [ $((i + 1)) -lt ${#USER_ARGS[@]} ]; then
+                printf '%s' "${USER_ARGS[i + 1]}"
+                return 0
+            fi
+            return 1
         fi
     done
     return 1
 }
 
+rand_secret() {
+    local s=""
+    if command -v openssl >/dev/null 2>&1; then
+        s=$(openssl rand -hex 16 2>/dev/null || true)
+    fi
+    if [ -z "$s" ] && [ -r /dev/urandom ]; then
+        s=$( (LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom 2>/dev/null | head -c 24) || true )
+    fi
+    if [ -z "$s" ]; then
+        s=$(od -An -tx1 -N16 /dev/urandom 2>/dev/null | tr -d ' \n' || true)
+    fi
+    if [ -z "$s" ]; then
+        echo "Error: unable to generate a random SOCKS5 password." >&2
+        return 1
+    fi
+    printf '%s' "$s"
+}
+
+# Generate SOCKS5 credentials once and persist them 0600.
+#
+# They reach the daemon through the environment, never as flags: Android's
+# loopback is not isolated per app, and anything on argv is readable by every
+# process on the device through /proc.
+ensure_socks_creds() {
+    if [ -z "${TS_SOCKS5_USER:-}" ] || [ -z "${TS_SOCKS5_PASS:-}" ]; then
+        load_credentials
+    fi
+    if [ -n "${TS_SOCKS5_USER:-}" ] && [ -n "${TS_SOCKS5_PASS:-}" ]; then
+        export TS_SOCKS5_USER TS_SOCKS5_PASS
+        return 0
+    fi
+
+    TS_SOCKS5_USER="termux"
+    TS_SOCKS5_PASS="$(rand_secret)"
+    (
+        umask 077
+        cat > "$CRED_FILE" << CREDS
+# Auto-generated SOCKS5 credentials for tailscaled.
+# Show them with:      tailscale-socks5
+# Regenerate them with: tailscale-socks5 --regenerate
+TS_SOCKS5_USER=$TS_SOCKS5_USER
+TS_SOCKS5_PASS=$TS_SOCKS5_PASS
+CREDS
+    )
+    chmod 600 "$CRED_FILE"
+    export TS_SOCKS5_USER TS_SOCKS5_PASS
+    echo "Generated SOCKS5 credentials in $CRED_FILE (see: tailscale-socks5)."
+}
+
+FINAL_ARGS=()
 has_flag "--statedir" || FINAL_ARGS+=("--statedir=$STATE_DIR")
 has_flag "--socket" || FINAL_ARGS+=("--socket=$SOCKET")
 has_flag "--tun" || FINAL_ARGS+=("--tun=userspace-networking")
 
-if ! has_flag "--socks5-server"; then
-    if [ -n "${TS_SOCKS5_SERVER:-}" ]; then SOCKS_VAL="$TS_SOCKS5_SERVER"
-    elif [ -n "${TS_SOCKS5_PORT:-}" ]; then SOCKS_VAL="127.0.0.1:$TS_SOCKS5_PORT"
-    else
-        RANDOM_PORT=$((RANDOM % 64511 + 1024))
-        SOCKS_VAL="127.0.0.1:$RANDOM_PORT"
-        echo "Using random SOCKS5 port: $RANDOM_PORT"
-    fi
-    FINAL_ARGS+=("--socks5-server=$SOCKS_VAL")
-else
-    if [ "$SOCKS_VAL" == "NEXT" ]; then
-        for ((i=0; i<${#USER_ARGS[@]}; i++)); do
-            if [[ "${USER_ARGS[i]}" == "--socks5-server" ]]; then SOCKS_VAL="${USER_ARGS[i+1]}"; break; fi
-        done
-    fi
+# SOCKS5 proxy address. Set TS_SOCKS5=off to run without a proxy at all.
+SOCKS_VAL=""
+if has_flag "--socks5-server"; then
+    SOCKS_VAL="$(flag_value "--socks5-server" || true)"
+elif [ -n "${TS_SOCKS5_SERVER:-}" ]; then
+    SOCKS_VAL="$TS_SOCKS5_SERVER"
+elif [ -n "${TS_SOCKS5_PORT:-}" ]; then
+    SOCKS_VAL="127.0.0.1:$TS_SOCKS5_PORT"
+elif [ "${TS_SOCKS5:-on}" != "off" ]; then
+    SOCKS_VAL="127.0.0.1:1055"
 fi
-echo "$SOCKS_VAL" > "$SOCKS_ADDR_FILE"
 
-if ! has_flag "--outbound-http-proxy-listen" && [ -n "${TS_HTTP_PROXY:-}" ]; then FINAL_ARGS+=("--outbound-http-proxy-listen=$TS_HTTP_PROXY"); fi
-if ! has_flag "--port" && [ -n "${TS_PORT:-}" ]; then FINAL_ARGS+=("--port=$TS_PORT"); fi
+if [ -n "$SOCKS_VAL" ]; then
+    has_flag "--socks5-server" || FINAL_ARGS+=("--socks5-server=$SOCKS_VAL")
+    case "${TS_SOCKS5_NO_AUTH:-}" in
+        1 | true | yes | on)
+            # Escape hatch for people upgrading with proxy clients that cannot
+            # send credentials. It reopens the proxy to every app on the device.
+            echo "Warning: TS_SOCKS5_NO_AUTH is set. The SOCKS5 proxy on $SOCKS_VAL"
+            echo "         accepts any app on this device, with no password."
+            unset TS_SOCKS5_USER TS_SOCKS5_PASS
+            ;;
+        *)
+            ensure_socks_creds
+            ;;
+    esac
+    printf '%s' "$SOCKS_VAL" > "$SOCKS_ADDR_FILE"
+else
+    rm -f "$SOCKS_ADDR_FILE"
+fi
 
-FINAL_ARGS+=("${USER_ARGS[@]}")
+if ! has_flag "--outbound-http-proxy-listen" && [ -n "${TS_HTTP_PROXY:-}" ]; then
+    FINAL_ARGS+=("--outbound-http-proxy-listen=$TS_HTTP_PROXY")
+fi
+if ! has_flag "--port" && [ -n "${TS_PORT:-}" ]; then
+    FINAL_ARGS+=("--port=$TS_PORT")
+fi
+
+# tailscaled reads verbosity and log opt-out from the environment; `set -a`
+# above already exported anything the user put in .env. These two lines only
+# translate the names this project has documented historically.
+if [ -n "${TS_VERBOSE:-}" ] && [ -z "${TS_LOG_VERBOSITY:-}" ]; then
+    export TS_LOG_VERBOSITY="$TS_VERBOSE"
+fi
+if [ -n "${TS_NO_LOGS:-}" ] && [ -z "${TS_NO_LOGS_NO_SUPPORT:-}" ]; then
+    export TS_NO_LOGS_NO_SUPPORT="$TS_NO_LOGS"
+fi
+
+FINAL_ARGS+=(${USER_ARGS[@]+"${USER_ARGS[@]}"})
 if [ -n "${TS_EXTRA_ARGS:-}" ]; then
-    read -ra EXTRA_ARR <<< "$TS_EXTRA_ARGS"
-    FINAL_ARGS+=("${EXTRA_ARR[@]}")
+    # eval, not `read -ra`, so quoted values survive:
+    # TS_EXTRA_ARGS='--hostname="my phone"' is one argument, not two.
+    # .env is already sourced above, so this grants no new capability.
+    eval "EXTRA_ARR=($TS_EXTRA_ARGS)"
+    FINAL_ARGS+=(${EXTRA_ARR[@]+"${EXTRA_ARR[@]}"})
+fi
+
+if [ "$FOREGROUND" -eq 1 ]; then
+    exec "$BIN_DIR/tailscaled" "${FINAL_ARGS[@]}"
 fi
 
 echo "Starting tailscaled..."
 nohup "$BIN_DIR/tailscaled" "${FINAL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
 
 sleep 2
-if pgrep -f "tailscaled.*$STATE_DIR" > /dev/null; then
-    echo "Done. SOCKS5 address: $SOCKS_VAL"
+if daemon_running; then
+    if [ -n "$SOCKS_VAL" ]; then
+        echo "Done. SOCKS5 address: $SOCKS_VAL (credentials: tailscale-socks5)"
+    else
+        echo "Done. SOCKS5 proxy disabled (TS_SOCKS5=off)."
+    fi
 else
     echo "Error: tailscaled failed to start. Check $LOG_FILE"
     exit 1
@@ -262,13 +494,46 @@ EOF
     cat << 'EOF' > "$helper_stop"
 #!/data/data/com.termux/files/usr/bin/env bash
 # Helper script to stop tailscaled in Termux
-set -eu
+set -euo pipefail
 
-STATE_DIR="$HOME/.tailscale"
-SOCKS_ADDR_FILE="$STATE_DIR/socks_addr"
+. "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/common.sh"
 
-pkill -f "tailscaled.*$STATE_DIR" || echo "tailscaled was not running."
+STOPPED=0
+
+# runit restarts anything it supervises, so killing the daemon under a
+# want-up service just hands it straight back.
+if service_present; then
+    if sv status tailscaled 2>/dev/null | grep -q '^run:'; then
+        echo "Stopping the tailscaled service..."
+        sv down tailscaled
+        STOPPED=1
+    fi
+fi
+
+PIDS="$(daemon_pids)"
+if [ -n "$PIDS" ]; then
+    echo "Stopping tailscaled (pid $PIDS)..."
+    # shellcheck disable=SC2086
+    kill $PIDS 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        daemon_running || break
+        sleep 0.5
+    done
+    PIDS="$(daemon_pids)"
+    if [ -n "$PIDS" ]; then
+        # shellcheck disable=SC2086
+        kill -9 $PIDS 2>/dev/null || true
+    fi
+    STOPPED=1
+fi
+
 rm -f "$SOCKS_ADDR_FILE"
+
+if [ "$STOPPED" -eq 1 ]; then
+    echo "tailscaled stopped."
+else
+    echo "tailscaled was not running."
+fi
 EOF
     chmod +x "$helper_stop"
 
@@ -276,12 +541,27 @@ EOF
     cat << 'EOF' > "$helper_log"
 #!/data/data/com.termux/files/usr/bin/env bash
 # Helper script to view tailscaled logs in Termux
-set -eu
+set -euo pipefail
 
-STATE_DIR="$HOME/.tailscale"
-LOG_FILE="$STATE_DIR/tailscaled.log"
+. "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/common.sh"
 
-tail -f "$LOG_FILE"
+# Under termux-services the daemon's output goes to svlogd, not to the nohup
+# log file that only the manual start path writes.
+if [ -f "$SVLOG_DIR/current" ]; then
+    echo "-> Following $SVLOG_DIR/current (termux-services)"
+    exec tail -f "$SVLOG_DIR/current"
+fi
+
+if [ -f "$LOG_FILE" ]; then
+    echo "-> Following $LOG_FILE"
+    exec tail -f "$LOG_FILE"
+fi
+
+echo "No log file found."
+echo "  Looked in: $SVLOG_DIR/current"
+echo "             $LOG_FILE"
+echo "Is the daemon running? Try: tailscaled-start --service=status"
+exit 1
 EOF
     chmod +x "$helper_log"
 
@@ -289,24 +569,32 @@ EOF
     cat << 'EOF' > "$helper_cli"
 #!/data/data/com.termux/files/usr/bin/env bash
 # Helper script to run tailscale CLI with correct socket
-set -eu
+set -euo pipefail
 
-STATE_DIR="$HOME/.tailscale"
-SOCKET="$STATE_DIR/tailscaled.sock"
-BIN_DIR="${PREFIX:-/data/data/com.termux/files/usr}/bin"
+. "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/common.sh"
+
+# An upgrade notice printed by dpkg scrolls past before anyone reads it, so
+# repeat it once here, the next time the user actually reaches for the CLI.
+NOTICE_FILE="$STATE_DIR/UPGRADE_NOTICE"
+SHOWN_MARKER="$STATE_DIR/.upgrade_notice_shown"
+if [ -f "$NOTICE_FILE" ] && [ ! -f "$SHOWN_MARKER" ]; then
+    cat "$NOTICE_FILE" >&2
+    echo "" >&2
+    : > "$SHOWN_MARKER" 2>/dev/null || true
+fi
 
 # Auto-start daemon if socket is missing or process is not running
-if [ ! -S "$SOCKET" ] || ! pgrep -f "tailscaled" > /dev/null 2>&1; then
+if [ ! -S "$SOCKET" ] || ! daemon_running; then
     echo "Notice: tailscaled is not running. Auto-starting daemon..."
-    if command -v sv >/dev/null 2>&1 && [ -d "${PREFIX:-/data/data/com.termux/files/usr}/var/service/tailscaled" ]; then
+    if service_present; then
         sv up tailscaled 2>/dev/null || true
     fi
-    if ! pgrep -f "tailscaled" > /dev/null 2>&1; then
+    if ! daemon_running; then
         if [ -x "$BIN_DIR/tailscaled-start" ]; then
             "$BIN_DIR/tailscaled-start" >/dev/null 2>&1 &
         fi
     fi
-    for i in {1..10}; do
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
         if [ -S "$SOCKET" ]; then break; fi
         sleep 0.5
     done
@@ -316,18 +604,96 @@ exec "$BIN_DIR/tailscale" --socket="$SOCKET" "$@"
 EOF
     chmod +x "$helper_cli"
 
+    # Helper: tailscale-socks5
+    cat << 'EOF' > "$helper_socks"
+#!/data/data/com.termux/files/usr/bin/env bash
+# Show (or regenerate) the SOCKS5 proxy credentials for tailscaled.
+set -euo pipefail
+
+. "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/common.sh"
+
+usage() {
+    echo "Usage: tailscale-socks5 [--regenerate] [--url] [--help]"
+    echo ""
+    echo "  (no flags)     Show the proxy address and credentials"
+    echo "  --regenerate   Issue a new password (restart the daemon to apply)"
+    echo "  --url          Print just the proxy URL, for scripts"
+}
+
+REGENERATE=0
+URL_ONLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --regenerate) REGENERATE=1 ;;
+        --url) URL_ONLY=1 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "Unknown option: $arg" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [ "$REGENERATE" -eq 1 ]; then
+    rm -f "$CRED_FILE"
+    echo "Credentials cleared. Restart the daemon to issue new ones:"
+    if service_present; then
+        echo "  sv restart tailscaled"
+    else
+        echo "  tailscaled-stop && tailscaled-start"
+    fi
+    exit 0
+fi
+
+load_credentials
+
+if [ -z "${TS_SOCKS5_USER:-}" ] || [ -z "${TS_SOCKS5_PASS:-}" ]; then
+    echo "No SOCKS5 credentials yet. They are generated the first time the"
+    echo "daemon starts. Start it with:"
+    echo "  tailscaled-start"
+    exit 1
+fi
+
+ADDR="$(live_socks_addr 2>/dev/null || true)"
+SOURCE="running daemon"
+if [ -z "$ADDR" ] && [ -f "$SOCKS_ADDR_FILE" ]; then
+    ADDR="$(cat "$SOCKS_ADDR_FILE")"
+    SOURCE="last recorded (daemon not running)"
+fi
+
+if [ -z "$ADDR" ]; then
+    echo "SOCKS5 proxy address unknown — the daemon does not appear to be running."
+    echo "Credentials on file: $TS_SOCKS5_USER / $TS_SOCKS5_PASS"
+    exit 1
+fi
+
+if [ "$URL_ONLY" -eq 1 ]; then
+    echo "socks5://$TS_SOCKS5_USER:$TS_SOCKS5_PASS@$ADDR"
+    exit 0
+fi
+
+echo "Tailscale SOCKS5 Proxy"
+echo "======================"
+echo "Address  : $ADDR   ($SOURCE)"
+echo "Username : $TS_SOCKS5_USER"
+echo "Password : $TS_SOCKS5_PASS"
+echo "URL      : socks5://$TS_SOCKS5_USER:$TS_SOCKS5_PASS@$ADDR"
+echo ""
+echo "Example  : curl --socks5-hostname $TS_SOCKS5_USER:$TS_SOCKS5_PASS@$ADDR https://api.ipify.org"
+echo ""
+echo "Anything on this device can reach $ADDR, so the password is what keeps"
+echo "other apps from using your tailnet. Treat it as a secret."
+EOF
+    chmod +x "$helper_socks"
+
     # Helper: tailscale-test
     cat << 'EOF' > "$helper_test"
 #!/data/data/com.termux/files/usr/bin/env bash
 # Helper script to test tailscaled status and connectivity in Termux
-set -eu
+set -euo pipefail
 
-STATE_DIR="$HOME/.tailscale"
-SOCKS_ADDR_FILE="$STATE_DIR/socks_addr"
+. "${PREFIX:-/data/data/com.termux/files/usr}/libexec/tailscale-termux/common.sh"
 
 echo "Tailscale Functional Test"
 echo "========================="
-if ! pgrep -f "tailscaled.*$STATE_DIR" > /dev/null; then
+if ! daemon_running; then
     echo "[-] Error: tailscaled is not running."
     exit 1
 fi
@@ -340,20 +706,39 @@ else
     exit 1
 fi
 
-if [ -f "$SOCKS_ADDR_FILE" ]; then
-    SOCKS_ADDR=$(cat "$SOCKS_ADDR_FILE")
-    echo "[*] Testing SOCKS5 on $SOCKS_ADDR..."
-    if curl -s --socks5 "$SOCKS_ADDR" https://1.1.1.1 > /dev/null; then
-        echo "[+] SOCKS5 Connectivity (Direct IP): OK"
-    else
-        echo "[-] SOCKS5 Connectivity (Direct IP): FAILED"
-    fi
-    if curl -s --socks5-hostname "$SOCKS_ADDR" https://api.ipify.org > /dev/null; then
-        echo "[+] SOCKS5 Resolution (Hostname): OK"
-    else
-        echo "[-] SOCKS5 Resolution (Hostname): FAILED (DNS issue in daemon)"
-        echo "    Tip: Use 'tailscale-cli up --accept-dns=false' or set global DNS in Admin Console."
-    fi
+# Ask the running daemon where it listens rather than trusting socks_addr,
+# which goes stale whenever the daemon is restarted by another path.
+SOCKS_ADDR="$(live_socks_addr 2>/dev/null || true)"
+if [ -z "$SOCKS_ADDR" ] && [ -f "$SOCKS_ADDR_FILE" ]; then
+    SOCKS_ADDR="$(cat "$SOCKS_ADDR_FILE")"
+fi
+
+if [ -z "$SOCKS_ADDR" ]; then
+    echo "[*] SOCKS5 test skipped: the daemon is running without --socks5-server."
+    echo "    Enable it by setting TS_SOCKS5_PORT in $ENV_FILE."
+    echo "========================="
+    exit 0
+fi
+
+load_credentials
+CURL_AUTH=""
+if [ -n "${TS_SOCKS5_USER:-}" ] && [ -n "${TS_SOCKS5_PASS:-}" ]; then
+    CURL_AUTH="$TS_SOCKS5_USER:$TS_SOCKS5_PASS@"
+else
+    echo "[!] No credentials on file; testing the proxy unauthenticated."
+fi
+
+echo "[*] Testing SOCKS5 on $SOCKS_ADDR..."
+if curl -s --socks5 "$CURL_AUTH$SOCKS_ADDR" https://1.1.1.1 > /dev/null; then
+    echo "[+] SOCKS5 Connectivity (Direct IP): OK"
+else
+    echo "[-] SOCKS5 Connectivity (Direct IP): FAILED"
+fi
+if curl -s --socks5-hostname "$CURL_AUTH$SOCKS_ADDR" https://api.ipify.org > /dev/null; then
+    echo "[+] SOCKS5 Resolution (Hostname): OK"
+else
+    echo "[-] SOCKS5 Resolution (Hostname): FAILED (DNS issue in daemon)"
+    echo "    Tip: Use 'tailscale-cli up --accept-dns=false' or set global DNS in Admin Console."
 fi
 echo "========================="
 EOF
@@ -362,14 +747,17 @@ EOF
     # Helper: tailscale-update (checks dpkg version and runs remote-install.sh if out of date)
     cat << 'EOF' > "$helper_update"
 #!/data/data/com.termux/files/usr/bin/env bash
-set -eu
+set -euo pipefail
 
 echo "Checking for updates..."
 REPO="bropines/tailscale-termux-cli"
-LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+# `|| true` because under `set -e` a failing grep (rate-limited API, no network)
+# aborts the script on the assignment, making the check below unreachable.
+LATEST_TAG=$(curl -fsS "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null | grep -Po '"tag_name": "\K.*?(?=")' || true)
 
 if [ -z "$LATEST_TAG" ]; then
     echo "Error: Could not retrieve latest release version."
+    echo "       GitHub may be rate-limiting this IP; try again later."
     exit 1
 fi
 
@@ -412,6 +800,56 @@ EOF
 set -e
 
 PREFIX="/data/data/com.termux/files/usr"
+TS_HOME="${HOME:-/data/data/com.termux/files/home}/.tailscale"
+
+# svlogd exits fatally if its log directory is missing, which leaves runsv
+# restarting the log service forever. Never fatal here though: under `set -e` a
+# failed mkdir would abort postinst and leave the package unconfigured.
+mkdir -p "$PREFIX/var/log/tailscaled" 2>/dev/null || true
+
+# dpkg passes the previously installed version as $2 on an upgrade, and
+# nothing on a fresh install. Only upgraders need warning about the change.
+if [ -n "${2:-}" ] && mkdir -p "$TS_HOME" 2>/dev/null; then
+    NOTICE="$TS_HOME/UPGRADE_NOTICE"
+    cat > "$NOTICE" << 'NOTICE_EOF'
+==========================================================
+ IMPORTANT: the SOCKS5 proxy now requires a password
+==========================================================
+Until this version the proxy on 127.0.0.1:1055 accepted any
+connection. That meant every app on this phone could route
+traffic through your tailnet as this node.
+
+It now requires a username and password, generated for you
+on the first daemon start. If a proxy client of yours stopped
+working after this update, that is why.
+
+  Show your credentials:   tailscale-socks5
+  Copy a ready-made URL:   tailscale-socks5 --url
+
+Also changed:
+  * The manual `tailscaled-start` used to pick a random port
+    each run; it now uses 127.0.0.1:1055, same as the service.
+  * ~/.tailscale/.env is now read on BOTH start paths, not
+    just the manual one.
+  * TS_VERBOSE is now applied (as TS_LOG_VERBOSITY). If you
+    had it set, expect more log output than before.
+
+If a client genuinely cannot send SOCKS5 credentials, put
+TS_SOCKS5_NO_AUTH=1 in ~/.tailscale/.env to restore the old
+open proxy -- but understand you are reopening it to every
+app on the device.
+
+Delete this file to dismiss: rm ~/.tailscale/UPGRADE_NOTICE
+==========================================================
+NOTICE_EOF
+    chmod 644 "$NOTICE" 2>/dev/null || true
+    # Let tailscale-cli show it again on first use: dpkg's output scrolls past.
+    rm -f "$TS_HOME/.upgrade_notice_shown"
+    echo ""
+    cat "$NOTICE"
+    echo ""
+fi
+
 if command -v termux-fix-shebang >/dev/null 2>&1; then
     termux-fix-shebang "$PREFIX/bin/tailscaled-start" \
                        "$PREFIX/bin/tailscaled-stop" \
@@ -419,6 +857,7 @@ if command -v termux-fix-shebang >/dev/null 2>&1; then
                        "$PREFIX/bin/tailscale-cli" \
                        "$PREFIX/bin/tailscale-test" \
                        "$PREFIX/bin/tailscale-update" \
+                       "$PREFIX/bin/tailscale-socks5" \
                        "$PREFIX/var/service/tailscaled/run" 2>/dev/null || true
 fi
 
@@ -447,16 +886,30 @@ EOF
 if [ "$TARGET_ARCH" = "all" ]; then
     ./build.sh all
 else
-    if [ ! -f "$BIN_DIR/$TARGET_ARCH/tailscale" ] || [ ! -f "$BIN_DIR/$TARGET_ARCH/tailscaled" ]; then
+    if ! binaries_are_current "$TARGET_ARCH"; then
         ./build.sh "$TARGET_ARCH"
     fi
 fi
 
 if [ "$TARGET_ARCH" = "all" ]; then
-    for arch in aarch64 arm i686 x86_64; do
+    ARCHES=(aarch64 arm i686 x86_64)
+    PIDS=()
+    for arch in "${ARCHES[@]}"; do
         build_deb_for_arch "$arch" &
+        PIDS+=("$!")
     done
-    wait
+    # A bare `wait` always returns 0, so a failed package used to be announced
+    # as "All requested packages built successfully".
+    FAILED=""
+    for i in "${!PIDS[@]}"; do
+        if ! wait "${PIDS[$i]}"; then
+            FAILED="$FAILED ${ARCHES[$i]}"
+        fi
+    done
+    if [ -n "$FAILED" ]; then
+        echo "Error: packaging failed for:$FAILED"
+        exit 1
+    fi
 else
     build_deb_for_arch "$TARGET_ARCH"
 fi

--- a/checksums/v1.98.3.sha256
+++ b/checksums/v1.98.3.sha256
@@ -1,0 +1,1 @@
+9283ddbbf0a21ad37c725e09ac302aa96b37f00ca4b4142c00519cf983de0aa1  tailscale-v1.98.3.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,12 @@
 #!/data/data/com.termux/files/usr/bin/env bash
 # Tailscale Termux Local Builder & Installer
 # Detects host architecture, compiles binaries, generates completions/services, packages them as a .deb, and installs it.
-set -eu
+set -euo pipefail
 
 echo "Tailscale Termux Local Builder & Installer"
 echo "========================================="
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
 
 # 1. Detect architecture
 HOST_ARCH=$(go env GOARCH 2>/dev/null || echo "")
@@ -27,34 +29,67 @@ else
         arm)   TARGET_ARCH="arm"     ;;
         386)   TARGET_ARCH="i686"    ;;
         amd64) TARGET_ARCH="x86_64"  ;;
-        *)     TARGET_ARCH="aarch64" ;;
+        *)
+            # Defaulting to aarch64 here just buys a long build followed by an
+            # opaque dpkg architecture error.
+            echo "Error: Unsupported Go architecture '$HOST_ARCH'."
+            echo "       Supported: arm64, arm, 386, amd64."
+            exit 1
+            ;;
     esac
 fi
 
-# 2. Build the deb package
-echo "-> Building package for $TARGET_ARCH..."
+# 2. Build the deb package.
+# Pin the version here so we can name the resulting file exactly, instead of
+# globbing dist/ and hoping.
+if [ -z "${TS_VERSION:-}" ]; then
+    TS_VERSION=$(git describe --tags --always 2>/dev/null || echo "1.100.0")
+fi
+export TS_VERSION
+DEB_VERSION=$(echo "$TS_VERSION" | sed 's/^v//' | tr '-' '.')
+
+echo "-> Building package for $TARGET_ARCH (version $DEB_VERSION)..."
 chmod +x ./build_deb.sh ./build.sh
 ./build_deb.sh "$TARGET_ARCH"
 
 # 3. Find the built deb package
-DEB_FILE=$(ls dist/tailscale-termux_*_${TARGET_ARCH}.deb 2>/dev/null | head -n 1)
-if [ -z "$DEB_FILE" ]; then
+DEB_FILE="dist/tailscale-termux_${DEB_VERSION}_${TARGET_ARCH}.deb"
+if [ ! -f "$DEB_FILE" ]; then
+    # Fall back to the newest matching package rather than `ls | head -n 1`,
+    # which sorts lexicographically and so picks the *oldest* build
+    # ("...1.100.0.1" sorts before "...1.100.0.9").
+    DEB_FILE=$(find dist -maxdepth 1 -name "tailscale-termux_*_${TARGET_ARCH}.deb" -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -n1 | cut -d' ' -f2-)
+fi
+if [ -z "$DEB_FILE" ] || [ ! -f "$DEB_FILE" ]; then
     echo "Error: Generated .deb package not found in dist/"
     exit 1
 fi
 
 # 4. Install via dpkg + apt
 echo "-> Installing package: $DEB_FILE..."
-# Stop existing daemon if running
-pkill -f tailscaled || true
+# Stop the service properly. A bare `pkill -f tailscaled` also matches this
+# project's own `runsv tailscaled`, `svlogd` and `tail -f ...tailscaled.log`,
+# and killing runsv only makes runit restart the daemon mid-install.
+if command -v sv >/dev/null 2>&1 && [ -d "$PREFIX/var/service/tailscaled" ]; then
+    sv down tailscaled 2>/dev/null || true
+fi
+pkill -f -- "--statedir=$HOME/.tailscale" 2>/dev/null || true
 
-dpkg -i "$DEB_FILE"
+# dpkg -i exits 1 on an unmet dependency after unpacking but not configuring;
+# `|| true` lets `apt install -f` below actually repair it.
+dpkg -i "$DEB_FILE" || true
 if command -v apt >/dev/null 2>&1; then
     echo "-> Checking/fixing dependencies..."
     apt install -f -y
 fi
 
-PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+if ! dpkg-query -W -f='${Status}' tailscale-termux 2>/dev/null | grep -q "install ok installed"; then
+    echo "Error: the package was unpacked but not configured."
+    echo "       Try: apt install -f -y && dpkg -i '$DEB_FILE'"
+    exit 1
+fi
+
 if [ -f "$HOME/bin/tailscale" ] || [ -f "$HOME/bin/tailscaled" ]; then
     echo "-> Removing stale binaries from $HOME/bin to avoid PATH conflict..."
     rm -f "$HOME/bin/tailscale" "$HOME/bin/tailscaled" "$HOME/bin/tailscaled-start" 2>/dev/null || true
@@ -67,6 +102,7 @@ if command -v termux-fix-shebang >/dev/null 2>&1; then
                        "$PREFIX/bin/tailscale-cli" \
                        "$PREFIX/bin/tailscale-test" \
                        "$PREFIX/bin/tailscale-update" \
+                       "$PREFIX/bin/tailscale-socks5" \
                        "$PREFIX/var/service/tailscaled/run" 2>/dev/null || true
 fi
 
@@ -80,4 +116,7 @@ echo "========================================="
 echo "Local Installation Complete!"
 echo "Daemon is starting/running. To authenticate, run:"
 echo "  tailscale-cli up"
+echo ""
+echo "The SOCKS5 proxy requires a password. See it with:"
+echo "  tailscale-socks5"
 echo "========================================="

--- a/patches/fix_android_netmon.go
+++ b/patches/fix_android_netmon.go
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Termux patch for cmd/tailscaled. See LICENSE at the repository root.
+
 //go:build android || linux
 
 package main

--- a/patches/fix_android_netmon.go
+++ b/patches/fix_android_netmon.go
@@ -1,4 +1,4 @@
-//go:build android
+//go:build android || linux
 
 package main
 
@@ -104,6 +104,24 @@ func detectIPv6Addr() net.IP {
 	return nil
 }
 
+// termuxDNSServer returns the resolver address tailscaled should dial, or ""
+// to keep Go's default resolver. Controlled by TS_DNS_SERVER: unset means
+// 8.8.8.8:53, "system"/"default"/"off" means no override, anything else is
+// used verbatim (a bare IP gets :53 appended).
+func termuxDNSServer() string {
+	v := strings.TrimSpace(os.Getenv("TS_DNS_SERVER"))
+	switch strings.ToLower(v) {
+	case "":
+		return "8.8.8.8:53"
+	case "system", "default", "off":
+		return ""
+	}
+	if _, _, err := net.SplitHostPort(v); err != nil {
+		return net.JoinHostPort(v, "53")
+	}
+	return v
+}
+
 func init() {
 	// 1. Mask as CLI to bypass mobile-specific policies
 	hostinfo.RegisterHostinfoNewHook(func(hi *tailcfg.Hostinfo) {
@@ -115,15 +133,32 @@ func init() {
 		fmt.Printf("[Termux] Masking App as: %s, DeviceModel: %s\n", hi.App, hi.DeviceModel)
 	})
 
-	// 2. Redirect DNS to 8.8.8.8 directly (bypass broken netlink on Android)
-	net.DefaultResolver = &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			var d net.Dialer
-			return d.DialContext(ctx, "udp", "8.8.8.8:53")
-		},
+	// 2. Install a resolver.
+	//
+	// The binaries are built with CGO_ENABLED=0, so Go uses its pure-Go
+	// resolver, which reads /etc/resolv.conf — a file Termux does not have.
+	// Without this the daemon cannot resolve the control plane at all.
+	//
+	// Configurable via TS_DNS_SERVER in ~/.tailscale/.env; "system" keeps
+	// Go's default resolver. See README for the privacy trade-off.
+	if dns := termuxDNSServer(); dns != "" {
+		net.DefaultResolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				var d net.Dialer
+				// Honour the caller's transport: Go retries over TCP when a
+				// UDP answer comes back truncated, and forcing that retry
+				// onto UDP would lose the very answers it exists to fetch.
+				if strings.HasPrefix(network, "tcp") {
+					return d.DialContext(ctx, "tcp", dns)
+				}
+				return d.DialContext(ctx, "udp", dns)
+			},
+		}
+		fmt.Printf("[Termux] DNS resolver pinned to %s\n", dns)
+	} else {
+		fmt.Printf("[Termux] DNS resolver: system default\n")
 	}
-	fmt.Printf("[Termux] Global DNS redirected to 8.8.8.8\n")
 
 	// 3. Register custom interface getter:
 	//    - Interface list: anet.Interfaces() (ioctl-based, works on Android 11+)

--- a/patches/fix_args_android.go
+++ b/patches/fix_args_android.go
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Termux patch for cmd/tailscaled. See LICENSE at the repository root.
+
 //go:build android || linux
 
 package main
@@ -41,4 +45,3 @@ func init() {
 		}
 	}
 }
-

--- a/patches/fix_socks5_auth.go
+++ b/patches/fix_socks5_auth.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Termux patch: SOCKS5 credentials for tailscaled.
+//
+// Upstream's socks5.Server already supports Username/Password (see
+// net/socks5/socks5.go), but cmd/tailscaled never populates them, so
+// --socks5-server always listens unauthenticated. On Android the loopback
+// interface is not isolated per-app: any installed app holding only the
+// INTERNET permission can reach 127.0.0.1:<port> and get egress into the
+// tailnet with this node's identity.
+//
+// build.sh injects Username/Password into the socks5.Server literal in
+// cmd/tailscaled/proxy.go, calling the two helpers below. Credentials are
+// read from the environment rather than from flags so they never appear in
+// the process cmdline (visible to every process on the device via /proc).
+//
+// tailscaled-start generates and persists them; `tailscale-socks5` prints
+// them back to the user.
+
+//go:build !ts_omit_outboundproxy
+
+package main
+
+import "os"
+
+// termuxSocks5User returns the SOCKS5 username the proxy requires, or "" to
+// keep the proxy unauthenticated.
+func termuxSocks5User() string {
+	return os.Getenv("TS_SOCKS5_USER")
+}
+
+// termuxSocks5Pass returns the SOCKS5 password the proxy requires, or "" to
+// keep the proxy unauthenticated.
+func termuxSocks5Pass() string {
+	return os.Getenv("TS_SOCKS5_PASS")
+}

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -26,6 +26,7 @@ REQUIREMENTS=(
     # The package depends on termux-services. Without it here, the install
     # leaves an unconfigured package behind.
     "sv:termux-services"
+    "sha256sum:coreutils"
 )
 if [ "$PKG_FORMAT" = "deb" ]; then
     REQUIREMENTS+=("zstd:zstd")
@@ -107,6 +108,27 @@ if ! wget -q --show-progress -O "$DOWNLOAD_DIR/$DEB_FILE" "$DEB_URL"; then
     rm -f "$DOWNLOAD_DIR/$DEB_FILE"
     echo "Error: failed to download $DEB_URL"
     exit 1
+fi
+
+# Verify against the checksums published with the release. This is what makes
+# publishing SHA256SUMS worth anything; the download itself is a plain fetch.
+echo " -> Verifying checksum..."
+EXPECTED_SHA=$(curl -fsSL "https://github.com/$REPO/releases/download/$LATEST_TAG/SHA256SUMS" 2>/dev/null \
+    | awk -v f="$DEB_FILE" '{ n = $2; sub(/^\.\//, "", n); if (n == f) print $1 }' | head -n1 || true)
+if [ -n "$EXPECTED_SHA" ]; then
+    ACTUAL_SHA=$(sha256sum "$DOWNLOAD_DIR/$DEB_FILE" | cut -d' ' -f1)
+    if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+        rm -f "$DOWNLOAD_DIR/$DEB_FILE"
+        echo "Error: checksum mismatch for $DEB_FILE."
+        echo "       expected: $EXPECTED_SHA"
+        echo "       actual:   $ACTUAL_SHA"
+        echo "       Refusing to install. Report this if it persists."
+        exit 1
+    fi
+    echo "    OK ($ACTUAL_SHA)"
+else
+    # Releases published before SHA256SUMS existed have nothing to check.
+    echo "    No SHA256SUMS published for $LATEST_TAG; skipping verification."
 fi
 
 echo "[3/3] Installing package..."

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -6,17 +6,30 @@ set -euo pipefail
 echo "Tailscale Termux Remote Installer"
 echo "=============================="
 
+# Termux ships both a dpkg-based and a pacman-based variant (issue #9).
+if command -v dpkg >/dev/null 2>&1; then
+    PKG_FORMAT="deb"
+elif command -v pacman >/dev/null 2>&1; then
+    PKG_FORMAT="pacman"
+else
+    echo "Error: neither dpkg nor pacman was found."
+    echo "       This does not look like a Termux environment."
+    exit 1
+fi
+echo "[*] Package manager: $PKG_FORMAT"
+
 echo "[*] Checking requirements..."
 REQUIREMENTS=(
     "curl:curl"
     "wget:wget"
     "grep:grep"
-    "dpkg:dpkg"
-    "zstd:zstd"
-    # The package declares Depends: termux-services. Without it here, dpkg -i
-    # refuses to configure the package and the install ends half-done.
+    # The package depends on termux-services. Without it here, the install
+    # leaves an unconfigured package behind.
     "sv:termux-services"
 )
+if [ "$PKG_FORMAT" = "deb" ]; then
+    REQUIREMENTS+=("zstd:zstd")
+fi
 
 MISSING_PKGS=""
 for req in "${REQUIREMENTS[@]}"; do
@@ -75,9 +88,13 @@ case "$ARCH" in
 esac
 echo "-> Detected architecture: $ARCH"
 
-# Convert LATEST_TAG for deb version (e.g. v1.100.0 -> 1.100.0)
+# Convert LATEST_TAG to a package version (e.g. v1.100.0-3 -> 1.100.0.3)
 DEB_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//' | tr '-' '.')
-DEB_FILE="tailscale-termux_${DEB_VERSION}_${ARCH}.deb"
+if [ "$PKG_FORMAT" = "deb" ]; then
+    DEB_FILE="tailscale-termux_${DEB_VERSION}_${ARCH}.deb"
+else
+    DEB_FILE="tailscale-termux-${DEB_VERSION}-1-${ARCH}.pkg.tar.xz"
+fi
 DEB_URL="https://github.com/$REPO/releases/download/$LATEST_TAG/$DEB_FILE"
 
 echo "[2/3] Downloading package: $DEB_FILE..."
@@ -92,30 +109,39 @@ if ! wget -q --show-progress -O "$DOWNLOAD_DIR/$DEB_FILE" "$DEB_URL"; then
     exit 1
 fi
 
-echo "[3/3] Installing package via dpkg..."
+echo "[3/3] Installing package..."
 # Stop the service first. A bare `pkill -f tailscaled` matches this project's
 # own `runsv tailscaled`, `svlogd` and `tail -f ...tailscaled.log` processes,
 # and killing runsv just makes runit restart the daemon a second later --
-# in the middle of dpkg -i.
+# in the middle of the install.
 if command -v sv >/dev/null 2>&1 && [ -d "$PREFIX/var/service/tailscaled" ]; then
     sv down tailscaled 2>/dev/null || true
 fi
 pkill -f -- "--statedir=$HOME/.tailscale" 2>/dev/null || true
 
-# dpkg -i avoids privilege-dropping metadata read errors in user directories.
-# It exits 1 when a dependency is unmet, having unpacked but not configured the
-# package -- `|| true` lets the `apt install -f` below actually do its job.
-dpkg -i "$DOWNLOAD_DIR/$DEB_FILE" || true
-if command -v apt >/dev/null 2>&1; then
-    apt install -f -y
-fi
-
-# Confirm the package really is configured, rather than trusting the banner.
-if ! dpkg-query -W -f='${Status}' tailscale-termux 2>/dev/null | grep -q "install ok installed"; then
-    echo "Error: the package was unpacked but not configured."
-    echo "       The .deb is kept at: $DOWNLOAD_DIR/$DEB_FILE"
-    echo "       Try: apt install -f -y && dpkg -i '$DOWNLOAD_DIR/$DEB_FILE'"
-    exit 1
+if [ "$PKG_FORMAT" = "deb" ]; then
+    # dpkg -i avoids privilege-dropping metadata read errors in user
+    # directories. It exits 1 when a dependency is unmet, having unpacked but
+    # not configured the package -- `|| true` lets `apt install -f` repair it.
+    dpkg -i "$DOWNLOAD_DIR/$DEB_FILE" || true
+    if command -v apt >/dev/null 2>&1; then
+        apt install -f -y
+    fi
+    # Confirm the package really is configured, rather than trusting the banner.
+    if ! dpkg-query -W -f='${Status}' tailscale-termux 2>/dev/null | grep -q "install ok installed"; then
+        echo "Error: the package was unpacked but not configured."
+        echo "       The package is kept at: $DOWNLOAD_DIR/$DEB_FILE"
+        echo "       Try: apt install -f -y && dpkg -i '$DOWNLOAD_DIR/$DEB_FILE'"
+        exit 1
+    fi
+else
+    pacman -U --noconfirm "$DOWNLOAD_DIR/$DEB_FILE" || true
+    if ! pacman -Q tailscale-termux >/dev/null 2>&1; then
+        echo "Error: pacman did not install the package."
+        echo "       The package is kept at: $DOWNLOAD_DIR/$DEB_FILE"
+        echo "       Try: pacman -U '$DOWNLOAD_DIR/$DEB_FILE'"
+        exit 1
+    fi
 fi
 
 if [ -f "$HOME/bin/tailscale" ] || [ -f "$HOME/bin/tailscaled" ]; then

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -1,7 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/env bash
 # Tailscale Termux Remote Installer
 # Automates downloading and installing the architecture-specific deb package.
-set -eu
+set -euo pipefail
 
 echo "Tailscale Termux Remote Installer"
 echo "=============================="
@@ -13,6 +13,9 @@ REQUIREMENTS=(
     "grep:grep"
     "dpkg:dpkg"
     "zstd:zstd"
+    # The package declares Depends: termux-services. Without it here, dpkg -i
+    # refuses to configure the package and the install ends half-done.
+    "sv:termux-services"
 )
 
 MISSING_PKGS=""
@@ -26,18 +29,26 @@ done
 
 if [ -n "$MISSING_PKGS" ]; then
     echo " -> Installing missing dependencies:$MISSING_PKGS"
+    # shellcheck disable=SC2086
     pkg install -y $MISSING_PKGS
 else
     echo " -> All installer dependencies are present."
 fi
 
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
 REPO="bropines/tailscale-termux-cli"
 
 echo "[1/3] Fetching latest release info..."
-LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+# `|| true` is load-bearing: under `set -e` a failing grep (GitHub rate-limits
+# unauthenticated API calls to 60/hour per IP, which carrier NAT reaches easily)
+# aborts the script on this assignment, making the check below unreachable.
+LATEST_TAG=$(curl -fsS "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null | grep -Po '"tag_name": "\K.*?(?=")' || true)
 
 if [ -z "$LATEST_TAG" ]; then
-    echo "Error: No releases found."
+    echo "Error: could not fetch the latest release."
+    echo "       GitHub may be rate-limiting this IP, or there is no network."
+    echo "       Try again later, or download the .deb manually from:"
+    echo "       https://github.com/$REPO/releases/latest"
     exit 1
 fi
 echo "-> Latest Release: $LATEST_TAG"
@@ -70,23 +81,43 @@ DEB_FILE="tailscale-termux_${DEB_VERSION}_${ARCH}.deb"
 DEB_URL="https://github.com/$REPO/releases/download/$LATEST_TAG/$DEB_FILE"
 
 echo "[2/3] Downloading package: $DEB_FILE..."
-# Create a temporary directory to download
-TMP_DIR=$(mktemp -d "$HOME/tmp.XXXXXX")
-trap 'rm -rf "$TMP_DIR"' EXIT
+# Keep the download outside the trap's reach so a failed install can be retried
+# by hand instead of leaving a half-configured package and no .deb to fix it with.
+DOWNLOAD_DIR="$HOME/.cache/tailscale-termux"
+mkdir -p "$DOWNLOAD_DIR"
 
-wget -q --show-progress -O "$TMP_DIR/$DEB_FILE" "$DEB_URL"
+if ! wget -q --show-progress -O "$DOWNLOAD_DIR/$DEB_FILE" "$DEB_URL"; then
+    rm -f "$DOWNLOAD_DIR/$DEB_FILE"
+    echo "Error: failed to download $DEB_URL"
+    exit 1
+fi
 
 echo "[3/3] Installing package via dpkg..."
-# Stop existing daemon if running
-pkill -f tailscaled || true
+# Stop the service first. A bare `pkill -f tailscaled` matches this project's
+# own `runsv tailscaled`, `svlogd` and `tail -f ...tailscaled.log` processes,
+# and killing runsv just makes runit restart the daemon a second later --
+# in the middle of dpkg -i.
+if command -v sv >/dev/null 2>&1 && [ -d "$PREFIX/var/service/tailscaled" ]; then
+    sv down tailscaled 2>/dev/null || true
+fi
+pkill -f -- "--statedir=$HOME/.tailscale" 2>/dev/null || true
 
-# Use dpkg -i to avoid privilege-dropping metadata read errors in user directories, then fix deps
-dpkg -i "$TMP_DIR/$DEB_FILE"
+# dpkg -i avoids privilege-dropping metadata read errors in user directories.
+# It exits 1 when a dependency is unmet, having unpacked but not configured the
+# package -- `|| true` lets the `apt install -f` below actually do its job.
+dpkg -i "$DOWNLOAD_DIR/$DEB_FILE" || true
 if command -v apt >/dev/null 2>&1; then
     apt install -f -y
 fi
 
-PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+# Confirm the package really is configured, rather than trusting the banner.
+if ! dpkg-query -W -f='${Status}' tailscale-termux 2>/dev/null | grep -q "install ok installed"; then
+    echo "Error: the package was unpacked but not configured."
+    echo "       The .deb is kept at: $DOWNLOAD_DIR/$DEB_FILE"
+    echo "       Try: apt install -f -y && dpkg -i '$DOWNLOAD_DIR/$DEB_FILE'"
+    exit 1
+fi
+
 if [ -f "$HOME/bin/tailscale" ] || [ -f "$HOME/bin/tailscaled" ]; then
     echo "-> Removing stale binaries from $HOME/bin to avoid PATH conflict..."
     rm -f "$HOME/bin/tailscale" "$HOME/bin/tailscaled" "$HOME/bin/tailscaled-start" 2>/dev/null || true
@@ -99,6 +130,7 @@ if command -v termux-fix-shebang >/dev/null 2>&1; then
                        "$PREFIX/bin/tailscale-cli" \
                        "$PREFIX/bin/tailscale-test" \
                        "$PREFIX/bin/tailscale-update" \
+                       "$PREFIX/bin/tailscale-socks5" \
                        "$PREFIX/var/service/tailscaled/run" 2>/dev/null || true
 fi
 
@@ -112,4 +144,7 @@ echo "============================================="
 echo "Installation Complete!"
 echo "Daemon is starting/running. To authenticate, run:"
 echo "  tailscale-cli up"
+echo ""
+echo "The SOCKS5 proxy requires a password. See it with:"
+echo "  tailscale-socks5"
 echo "============================================="

--- a/termux-services/tailscaled/run
+++ b/termux-services/tailscaled/run
@@ -1,12 +1,9 @@
 #!/data/data/com.termux/files/usr/bin/sh
 exec 2>&1
 
-TAILSCALE_HOME="$HOME/.tailscale"
-mkdir -p "$TAILSCALE_HOME"
-
-# Start tailscaled in userspace mode for Android 11+
-exec tailscaled \
-    --statedir="$TAILSCALE_HOME" \
-    --socket="$TAILSCALE_HOME/tailscaled.sock" \
-    --tun=userspace-networking \
-    --socks5-server=localhost:1055
+# Delegate to tailscaled-start rather than repeating the flag list here.
+#
+# When this script had its own hardcoded flags, ~/.tailscale/.env applied only
+# to the manual start path -- so the documented configuration silently did
+# nothing for anyone using the service, which is the default after install.
+exec tailscaled-start --foreground


### PR DESCRIPTION
Addresses the findings from `AUDIT.md`. Every claim below was verified against the code or the built artifacts, not taken on trust.

## Blockers

**The netmon patch was missing from 3 of 4 published architectures.** It is tagged `//go:build android`, but `build.sh` only set `GOOS=android` for `aarch64` — PR #4 switched armv7 to `GOOS=linux` to make it compile, and i686/x86_64 followed. Verified on the released binaries: aarch64 had the patch strings and `wlynxg/anet` references, the other three had zero. Users on 32-bit ARM or x86 were getting a stock daemon with exactly the netlink limitation this project exists to work around.

Setting `GOOS=android` everywhere does **not** work — Go requires external (cgo) linking for every Android target except `arm64`. The patches are now tagged `android || linux` instead, so they compile into the `GOOS=linux` targets. `-buildmode=pie` is also dropped from x86_64: with `CGO_ENABLED=0` it produced a dynamic ELF with `.interp=/lib64/ld-linux-x86-64.so.2`, a glibc loader Android does not have, so that binary could not start at all.

`verify_patched()` now greps each freshly built `tailscaled` for the netmon, `anet` and SOCKS5-auth markers and fails the build if any are missing. Confirmed on a full four-architecture build: all four pass.

**The SOCKS5 proxy was open to every app on the device.** Android's loopback is not isolated per app, so the unauthenticated proxy on the fixed `127.0.0.1:1055` gave any app holding only `INTERNET` egress into the tailnet with this node's identity. `socks5.Server` already has `Username`/`Password` upstream; `cmd/tailscaled` just never set them. Credentials are now generated on first start, stored `0600` in `~/.tailscale/socks5.env`, and passed through the environment rather than argv, where every process can read them via `/proc`.

Verified end to end against a real daemon: without credentials `curl` exits 97 (rejected by the SOCKS5 server); with them the request completes.

**The nightly updater could never publish.** The release step was gated on `github.event_name == 'workflow_call'`, but a reusable workflow inherits the *caller's* event — `schedule`. Confirmed on run 34073832941: all four builds succeeded, `Create Release` was **skipped**, and the job still reported success. Last actual release was 2026-08-02 while the cron kept running nightly. Also, upstream `v1.102.3` was compared against this repo's `v1.100.0-10`, which can never be equal, so four architectures were cross-compiled and discarded every night.

## Also fixed

- **One source of daemon flags.** The service `run` now execs `tailscaled-start --foreground`. `~/.tailscale/.env` was previously read only by the manual path, so every documented variable silently did nothing for the service — which is what `postinst` starts.
- **Scoped process matching.** `pkill -f tailscaled` matched this project's own `runsv`/`svlogd`/`tail` processes; `pgrep -f "tailscaled.*$STATE_DIR"` matched the helper's own cmdline. Verified on a host also running a system `tailscaled`: the old pattern matched 3 processes, the new stop leaves it untouched.
- **Install on a clean Termux.** `termux-services` is a declared dependency but was never a prerequisite; `dpkg -i` exits 1 on an unmet dependency and `set -eu` killed the script before the `apt install -f` meant to repair it.
- `tailscaled-stop` does `sv down` first; `tailscale-test` reads the live daemon's address and says so when there is no proxy; `tailscaled-log` follows the svlogd directory; the packaged `log/run` regains its `mkdir`.
- `TS_VERBOSE`/`TS_NO_LOGS` are mapped to the names `tailscaled` actually reads; both were documented but wired to nothing.
- Bounds-checked `--socks5-server` lookup, quote-preserving `TS_EXTRA_ARGS`, version-stamped source and binary caches, `pipefail`, real exit-code collection from parallel builds, `SHA256SUMS` on releases.

## Supply chain, licensing, packaging

- **The upstream tarball is now checksummed** before anything is unpacked, compiled or executed. `build.sh` used `wget | tar -xz` with no verification, then ran that code on the build machine — which for `install.sh` is the user's phone. `TS_REQUIRE_CHECKSUM=1` makes an unpinned version fatal.
- Shell completions reuse the binary just built instead of triggering a second host compile of upstream code, which on a Termux install is the same machine anyway.
- `LICENSE` claimed "All rights reserved" over what is, in the shipped artifacts, almost entirely Tailscale's BSD-3 code. It now says which parts it covers; the package ships `share/doc/tailscale-termux/copyright` as clause 2 requires.
- **Pacman packages (closes #9).** Termux's pacman variant had no package at all. The same staged payload now emits a `.pkg.tar.xz` alongside the `.deb`, `remote-install.sh` detects which package manager is present, and CI publishes both. Verified: `.PKGINFO`/`.INSTALL` first in the archive, no `DEBIAN` directory, correct per-arch metadata.
- The deb `postinst` and the pacman `.INSTALL` now call one on-device `post-install.sh` instead of two copies of the same logic.

## CI on pull requests

There was no PR check of any kind — only tag pushes, `workflow_dispatch` and the nightly call. That is how the unpatched architectures went unnoticed for months. PRs now run the same four-architecture matrix and publish nothing.

## Upgrade impact

Existing users' SOCKS5 clients **will** stop working. The post-install step distinguishes an upgrade from a fresh install and prints a notice explaining why and how to retrieve the credentials; `tailscale-cli` repeats it once, since package-manager output scrolls past. `TS_SOCKS5_NO_AUTH=1` restores the old behaviour for clients that cannot send credentials. Verified: notice on upgrade, none on fresh install, shown exactly once.

## Note

With this merged the nightly workflow **will** start publishing releases again. Consider gating the publish job behind an Actions environment with a required reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)